### PR TITLE
Enable custom redirect after workflow task completion

### DIFF
--- a/packages/behin-simple-workflow/src/Controllers/Core/RoutingController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/RoutingController.php
@@ -157,6 +157,16 @@ class RoutingController extends Controller
                 $inbox->save();
             }
         }
+        if ($request->filled('redirect_url')) {
+            $redirectUrl = str_replace('{CASE_ID}', $caseId, $request->redirect_url);
+            $redirectMessage = $request->input('redirect_message', trans('Saved'));
+            session()->flash('success', $redirectMessage);
+            return response()->json([
+                'status' => 200,
+                'msg' => $redirectMessage,
+                'url' => $redirectUrl,
+            ]);
+        }
         if($newInbox = InboxController::caseIsInUserInbox($caseId)){
             return response()->json([
                 'status' => 200,

--- a/packages/behin-simple-workflow/src/Views/Core/Inbox/public-show.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Inbox/public-show.blade.php
@@ -175,11 +175,10 @@
                 function(response) {
                     console.log(response);
                     if (response.status == 200) {
-                        show_message('{{ trans('fields.Saved') }}')
-                        // window.close();
                         if (response.url) {
                             window.location.href = response.url;
                         } else {
+                            show_message(response.msg)
                             window.location.href = '{{ route('simpleWorkflow.inbox.index') }}';
                         }
                     } else {

--- a/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
@@ -243,11 +243,10 @@
                 function(response) {
                     console.log(response);
                     if (response.status == 200) {
-                        show_message('{{ trans('fields.Saved') }}')
-                        // window.close();
                         if (response.url) {
                             window.location.href = response.url;
                         } else {
+                            show_message(response.msg)
                             window.location.href = '{{ route('simpleWorkflow.inbox.index') }}';
                         }
                     } else {


### PR DESCRIPTION
## Summary
- Add optional redirect URL support to Save & Next workflow route with success flash
- Skip inbox redirect in Save & Next JS when server supplies URL

## Testing
- `php vendor/bin/pest` *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE of type int)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dd90602c833293c23136cc52cc0c