### PR TITLE
Add resend OTP button with countdown

### DIFF
--- a/resources/views/auth/verify-otp.blade.php
+++ b/resources/views/auth/verify-otp.blade.php
@@ -140,6 +140,14 @@
                         <input type="submit" class="btn btn-gradient w-100 py-3">
                     </form>
 
+                    <form method="POST" action="{{ route('otp.send') }}" class="mt-3">
+                        @csrf
+                        <input type="hidden" name="phone" value="{{ $phone }}">
+                        <button type="submit" class="btn btn-outline-secondary w-100" id="resendBtn" disabled>
+                            ارسال مجدد کد (60)
+                        </button>
+                    </form>
+
                     <div class="mt-4 text-center">
                         @include('auth.partial.enamad-and-version')
                     </div>
@@ -164,5 +172,20 @@
             </div>
         </div>
     </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const resendBtn = document.getElementById('resendBtn');
+            let counter = 60;
+            const timer = setInterval(() => {
+                counter--;
+                resendBtn.textContent = `ارسال مجدد کد (${counter})`;
+                if (counter <= 0) {
+                    clearInterval(timer);
+                    resendBtn.textContent = 'ارسال مجدد کد';
+                    resendBtn.disabled = false;
+                }
+            }, 1000);
+        });
+    </script>
 @endsection
 


### PR DESCRIPTION
## Summary
- add resend OTP form with 60-second countdown
- enable resend after timer via JavaScript

## Testing
- `php artisan test` *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE of type int)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c2891488332b09b73fb70e3202d