### PR TITLE
Enable sidebar menus with direct links

### DIFF
--- a/config/sidebar.php
+++ b/config/sidebar.php
@@ -6,6 +6,7 @@ return [
         'dashboard' => [
             'icon' => 'dashboard',
             'fa_name' => 'داشبرد',
+            'route-url' => 'admin',
             'submenu' => [
                 'dashboard' => [ 'fa_name' => 'داشبرد', 'route-name' => '', 'route-url' => 'admin' ],
             ]
@@ -13,6 +14,7 @@ return [
         'workflow-inbox' => [
             'icon' => 'inbox',
             'fa_name' => 'کارتابل',
+            'route-name' => 'simpleWorkflow.inbox.index',
             'submenu' => [
                 'new-process' => [ 'fa_name' => 'فرایند جدید', 'route-name' => 'simpleWorkflow.process.startListView' ],
                 'inbox' => [ 'fa_name' => 'کارتابل', 'route-name' => 'simpleWorkflow.inbox.index' ],
@@ -22,6 +24,7 @@ return [
         'workflow-report' => [
             'icon' => 'report',
             'fa_name' => 'گزارشات کارتابل',
+            'route-name' => 'simpleWorkflowReport.index',
             'submenu' => [
                 'list' => [ 'fa_name' => 'لیست', 'route-name' => 'simpleWorkflowReport.index' ],
                 'summary' => [ 'fa_name' => 'خلاصه', 'route-name' => 'simpleWorkflowReport.summary-report.index' ],
@@ -32,6 +35,7 @@ return [
         'workflow' => [
             'icon' => 'account_tree',
             'fa_name' => 'گردش کار',
+            'route-name' => 'simpleWorkflow.process.index',
             'submenu' => [
                 'process' => [ 'fa_name' => 'فرایند', 'route-name' => 'simpleWorkflow.process.index' ],
                 'task-actors' => [ 'fa_name' => 'تسک ها', 'route-name' => 'simpleWorkflow.task-actors.index' ],
@@ -46,6 +50,7 @@ return [
         'translations' => [
             'icon' => 'language',
             'fa_name' => 'ترجمه',
+            'route-url' => '/translations',
             'submenu' => [
                 'index' => [ 'fa_name' => 'ترجمه', 'route-name' => '', 'route-url' => '/translations' ],
             ]
@@ -53,6 +58,7 @@ return [
         'users' => [
             'icon' => 'person',
             'fa_name' => 'کاربران',
+            'route-url' => 'user/all',
             'submenu' => [
                 'dashboard' => [ 'fa_name' => 'همه', 'route-name' => '', 'route-url' => 'user/all' ],
                 'role' => [ 'fa_name' => 'نقش ها', 'route-name' => 'role.listForm', 'route-url' => '' ],

--- a/resources/views/behin-layouts/main-sidebar.blade.php
+++ b/resources/views/behin-layouts/main-sidebar.blade.php
@@ -19,33 +19,51 @@
                     @foreach (config('sidebar.menu') as $menu)
                         @if ( access('منو >>' .$menu['fa_name']) )
                             <li class="nav-item">
-                                <a href="#" class="nav-link d-flex align-items-center" style="color: #fff; padding: 10px 15px;">
+                                @php
+                                    $hasLink = isset($menu['route-name']) || isset($menu['route-url']) || isset($menu['static-url']);
+                                    if ($hasLink) {
+                                        if (isset($menu['route-name']) && Route::has($menu['route-name'])) {
+                                            $menuLink = route($menu['route-name']);
+                                        } elseif (isset($menu['static-url'])) {
+                                            $menuLink = $menu['static-url'];
+                                        } else {
+                                            $menuLink = url($menu['route-url']);
+                                        }
+                                    } else {
+                                        $menuLink = '#';
+                                    }
+                                @endphp
+                                <a href="{{ $menuLink }}" class="nav-link d-flex align-items-center" style="color: #fff; padding: 10px 15px;">
                                     <i class="material-icons me-2">@isset($menu['icon']) {{ $menu['icon'] }} @else menu @endisset</i>
                                     <span>{{ $menu['fa_name'] }}</span>
-                                    <i class="material-icons ms-auto" style="font-size: 18px;">expand_more</i>
+                                    @if(!$hasLink && isset($menu['submenu']))
+                                        <i class="material-icons ms-auto" style="font-size: 18px;">expand_more</i>
+                                    @endif
                                 </a>
-                                <ul class="nav nav-treeview ms-3" style="border-left: 2px solid rgba(255,255,255,0.1); margin-left: 10px;">
-                                    @foreach ($menu['submenu'] as $submenu)
-                                        @if ( access('منو >>' .$menu['fa_name'] . '>>' . $submenu['fa_name'] ) )
-                                            <li class="nav-item">
-                                                <a 
-                                                    @isset($submenu['target']) target="{{ $submenu['target'] }}" @endisset
-                                                    href="@if(Route::has($submenu['route-name'])) 
-                                                                {{ route($submenu['route-name']) }} 
-                                                            @elseif(isset($submenu['static-url']))
-                                                                {{ $submenu['static-url'] }}
-                                                            @else
-                                                                {{ isset($submenu['route-url']) ? url($submenu['route-url']) : '' }} 
-                                                            @endif"
-                                                    class="nav-link" 
-                                                    style="color: #cfd8dc; padding: 8px 15px; transition: all 0.3s ease;">
-                                                    <i class="material-icons" style="font-size: 16px;">chevron_left</i>
-                                                    <span>{{ $submenu['fa_name'] }}</span>
-                                                </a>
-                                            </li>
-                                        @endif
-                                    @endforeach
-                                </ul>
+                                @if(!$hasLink && isset($menu['submenu']))
+                                    <ul class="nav nav-treeview ms-3" style="border-left: 2px solid rgba(255,255,255,0.1); margin-left: 10px;">
+                                        @foreach ($menu['submenu'] as $submenu)
+                                            @if ( access('منو >>' .$menu['fa_name'] . '>>' . $submenu['fa_name'] ) )
+                                                <li class="nav-item">
+                                                    <a
+                                                        @isset($submenu['target']) target="{{ $submenu['target'] }}" @endisset
+                                                        href="@if(Route::has($submenu['route-name']))
+                                                                    {{ route($submenu['route-name']) }}
+                                                                @elseif(isset($submenu['static-url']))
+                                                                    {{ $submenu['static-url'] }}
+                                                                @else
+                                                                    {{ isset($submenu['route-url']) ? url($submenu['route-url']) : '' }}
+                                                                @endif"
+                                                        class="nav-link"
+                                                        style="color: #cfd8dc; padding: 8px 15px; transition: all 0.3s ease;">
+                                                        <i class="material-icons" style="font-size: 16px;">chevron_left</i>
+                                                        <span>{{ $submenu['fa_name'] }}</span>
+                                                    </a>
+                                                </li>
+                                            @endif
+                                        @endforeach
+                                    </ul>
+                                @endif
                             </li>
                         @endif
                     @endforeach


### PR DESCRIPTION
## Summary
- support clickable sidebar menu items with optional submenu fallback
- add route or URL options for top-level sidebar entries

## Testing
- `php vendor/bin/pest` *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE)*

------
https://chatgpt.com/codex/tasks/task_e_68bac3d4122883329db81943bed45b91