### PR TITLE
feat(workflow): execute script before opening tasks

### DIFF
--- a/packages/behin-simple-workflow/src/Controllers/Core/InboxController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/InboxController.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use Behin\SimpleWorkflow\Controllers\Core\ScriptController;
 use App\Events\NewInboxEvent;
 use App\Models\User;
 use BaleBot\Controllers\BotController;
@@ -166,6 +167,13 @@ class InboxController extends Controller
         $variables = VariableController::getVariablesByCaseId($case->id, $process->id);
 
         if ($task->type == 'form') {
+            if ($task->script_before_open) {
+                try {
+                    ScriptController::runScript($task->script_before_open, $case->id);
+                } catch (\Throwable $e) {
+                    Log::error('script_before_open failed: ' . $e->getMessage());
+                }
+            }
             if (!isset($form->content)) {
                 return redirect()->route('simpleWorkflow.inbox.index')->with('error', trans('Form not found'));
             }

--- a/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
@@ -41,7 +41,7 @@ class TaskController extends Controller
 
     public function update(Request $request, Task $task)
     {
-        $task->update($request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back'));
+        $task->update($request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back', 'script_before_open'));
         // self::getById($request->id)->update($request->all());
         return redirect()->back()->with('success', trans('Updated Successfully'));
     }

--- a/packages/behin-simple-workflow/src/Lang/fa/fields.php
+++ b/packages/behin-simple-workflow/src/Lang/fa/fields.php
@@ -90,5 +90,6 @@ return [
     'Forms' => 'فرم ها',
     'Transfer cases to task' => 'انتقال کیس ها به تسک',
     'Task deleted successfully' => 'تسک با موفقیت حذف شد',
+    'script_before_open' => 'اسکریپت قبل از باز شدن',
 
 ];

--- a/packages/behin-simple-workflow/src/Migrations/2025_09_12_000000_add_script_before_open_to_tasks_table.php
+++ b/packages/behin-simple-workflow/src/Migrations/2025_09_12_000000_add_script_before_open_to_tasks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (!Schema::hasColumn('wf_task', 'script_before_open')) {
+                $table->uuid('script_before_open')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (Schema::hasColumn('wf_task', 'script_before_open')) {
+                $table->dropColumn('script_before_open');
+            }
+        });
+    }
+};

--- a/packages/behin-simple-workflow/src/Models/Core/Task.php
+++ b/packages/behin-simple-workflow/src/Models/Core/Task.php
@@ -47,6 +47,7 @@ class Task extends Model
         'timing_value',
         'timing_key_name',
         'number_of_task_to_back',
+        'script_before_open',
     ];
 
     public function getStyledNameAttribute()

--- a/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
@@ -122,6 +122,15 @@
                 </select>
             </div>
             <div class="col-md-6">
+                <label for="script_before_open" class="form-label">{{ trans('fields.script_before_open') }}</label>
+                <select name="script_before_open" id="script_before_open" class="form-control select2">
+                    <option value="">{{ trans('Select an option') }}</option>
+                    @foreach ($scripts as $script)
+                        <option value="{{ $script->id }}" {{ $script->id == $task->script_before_open ? 'selected' : '' }}>{{ $script->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-md-6">
                 <label for="assignment_type" class="form-label">{{ trans('Assignment') }}</label>
                 <select name="assignment_type" id="assignment_type" class="form-control">
                     <option value="">{{ trans('None') }}</option>


### PR DESCRIPTION
## Summary
- add `script_before_open` field to tasks
- run task-specific script before rendering inbox tasks
- expose script selector in task editor and add migration

## Testing
- `php vendor/bin/pest` *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE of type int)*

------
https://chatgpt.com/codex/tasks/task_e_68c2763c976083329c3ce762e60f33c2