### PR TITLE
Add stage-based workflow report with filtering

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/StageReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/StageReportController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Behin\SimpleWorkflowReport\Controllers\Core;
+
+use App\Http\Controllers\Controller;
+use Behin\SimpleWorkflow\Models\Core\Task;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class StageReportController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $openStatuses = ['new', 'opened', 'inProgress', 'draft'];
+
+        $caseVariables = DB::table('wf_variables')
+            ->select(
+                'case_id',
+                DB::raw("MAX(CASE WHEN `key` = 'customer_workshop_or_ceo_name' THEN value END) as customer_workshop_or_ceo_name"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_fullname' THEN value END) as customer_fullname"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_firstname' THEN value END) as customer_firstname"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_lastname' THEN value END) as customer_lastname"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_mobile' THEN value END) as customer_mobile"),
+                DB::raw("MAX(CASE WHEN `key` IN ('customer_nid','customer_national_id') THEN value END) as customer_national_id"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_province' THEN value END) as customer_province"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_address' THEN value END) as customer_address"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_postal_code' THEN value END) as customer_postal_code"),
+                DB::raw("MAX(CASE WHEN `key` = 'customer_city' THEN value END) as customer_city"),
+                DB::raw("MAX(CASE WHEN `key` IN ('request-contractor_id','contractor_id') THEN value END) as request_contractor_id"),
+                DB::raw("MAX(CASE WHEN `key` IN ('powerhouse_place_info-id','powerhouse_place_info_id') THEN value END) as powerhouse_place_info_id"),
+                DB::raw("MAX(CASE WHEN `key` IN ('electricity_bill_id','bill_id','request-bill_id','powerhouse_place_info-bill_id','powerhouse_place_info-electricity_bill_id','electricity_bill_identifier','subscription_code','subscription_id','subscriber_id') THEN value END) as bill_identifier")
+            )
+            ->groupBy('case_id');
+
+        $openCases = DB::table('wf_inbox')
+            ->select('case_id', 'task_id')
+            ->whereIn('status', $openStatuses)
+            ->distinct();
+
+        $query = DB::table('wf_cases as cases')
+            ->joinSub($openCases, 'open_cases', function ($join) {
+                $join->on('cases.id', '=', 'open_cases.case_id');
+            })
+            ->leftJoin('wf_task as tasks', 'tasks.id', '=', 'open_cases.task_id')
+            ->leftJoin('wf_process as process', 'process.id', '=', 'cases.process_id')
+            ->leftJoin('users as creators', 'creators.id', '=', 'cases.creator')
+            ->leftJoinSub($caseVariables, 'vars', function ($join) {
+                $join->on('vars.case_id', '=', 'cases.id');
+            })
+            ->leftJoin('users as contractors', 'contractors.id', '=', 'vars.request_contractor_id')
+            ->leftJoin('wf_entity_powerhouse_place_info as place', 'place.id', '=', 'vars.powerhouse_place_info_id')
+            ->select([
+                'cases.id as case_id',
+                'cases.number as case_number',
+                'cases.process_id',
+                'process.name as process_name',
+                'open_cases.task_id',
+                'tasks.name as task_name',
+                'tasks.styled_name as task_styled_name',
+                'creators.email as creator_email',
+                'contractors.id as contractor_id',
+                'contractors.name as contractor_name',
+                'vars.customer_workshop_or_ceo_name',
+                'vars.customer_fullname',
+                'vars.customer_firstname',
+                'vars.customer_lastname',
+                'vars.customer_mobile',
+                'vars.customer_national_id',
+                'vars.customer_province',
+                'vars.customer_address',
+                'vars.customer_postal_code',
+                'vars.customer_city',
+                'vars.bill_identifier',
+                'place.province as powerhouse_province',
+                'place.address as powerhouse_address',
+                'place.postal_code as powerhouse_postal_code',
+            ])
+            ->orderByDesc('cases.created_at');
+
+        $selectedTaskIds = array_filter((array) $request->input('tasks', []));
+        if (! empty($selectedTaskIds)) {
+            $query->whereIn('open_cases.task_id', $selectedTaskIds);
+        }
+
+        $rows = $query->get()->map(function ($row) {
+            $nameCandidates = [
+                $row->customer_workshop_or_ceo_name,
+                $row->customer_fullname,
+                trim(($row->customer_firstname ? $row->customer_firstname : '') . ' ' . ($row->customer_lastname ? $row->customer_lastname : '')),
+            ];
+            $nameCandidates = array_filter(array_map(function ($value) {
+                return $value ? trim($value) : null;
+            }, $nameCandidates));
+
+            $row->customer_name = $nameCandidates ? reset($nameCandidates) : null;
+            $row->province = $row->customer_province ?: $row->powerhouse_province;
+            $row->address = $row->customer_address ?: $row->powerhouse_address;
+            $row->postal_code = $row->customer_postal_code ?: $row->powerhouse_postal_code;
+            $row->current_stage = trim(strip_tags($row->task_styled_name ?? $row->task_name ?? '')) ?: null;
+
+            return [
+                'case_id' => $row->case_id,
+                'case_number' => $row->case_number,
+                'customer_name' => $row->customer_name,
+                'customer_mobile' => $row->creator_email ? trim($row->creator_email) : ($row->customer_mobile ? trim($row->customer_mobile) : null),
+                'customer_national_id' => $row->customer_national_id,
+                'province' => $row->province,
+                'contractor' => $row->contractor_name,
+                'bill_identifier' => $row->bill_identifier,
+                'postal_code' => $row->postal_code,
+                'address' => $row->address,
+                'current_stage' => $row->current_stage,
+            ];
+        })->values();
+
+        $tasks = Task::with('process')
+            ->whereIn('id', function ($query) use ($openStatuses) {
+                $query->select('task_id')
+                    ->from('wf_inbox')
+                    ->whereIn('status', $openStatuses);
+            })
+            ->orderBy('process_id')
+            ->orderBy('name')
+            ->get()
+            ->groupBy('process_id');
+
+        return view('SimpleWorkflowReportView::Core.Stage.index', [
+            'rows' => $rows,
+            'tasks' => $tasks,
+            'selectedTasks' => $selectedTaskIds,
+        ]);
+    }
+}

--- a/packages/behin-simple-workflow-report/src/Routes/web.php
+++ b/packages/behin-simple-workflow-report/src/Routes/web.php
@@ -14,6 +14,7 @@ use Behin\SimpleWorkflowReport\Controllers\Core\ChequeReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\ExpiredController;
 use Behin\SimpleWorkflowReport\Controllers\Core\ExternalAndInternalReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\MyRequestController;
+use Behin\SimpleWorkflowReport\Controllers\Core\StageReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\RoleReportFormController;
 use Behin\SimpleWorkflowReport\Controllers\Core\SummaryReportController;
 use Behin\SimpleWorkflowReport\Controllers\Core\PersonelActivityController;
@@ -25,8 +26,10 @@ use Maatwebsite\Excel\Facades\Excel;
 
 Route::name('simpleWorkflowReport.')->prefix('workflow-report')->middleware(['web', 'auth'])->group(function () {
     Route::resource('summary-report', SummaryReportController::class);
-    
+
     Route::resource('my-request', MyRequestController::class);
+
+    Route::get('stage-report', [StageReportController::class, 'index'])->name('stage-report.index');
 
 
 });

--- a/packages/behin-simple-workflow-report/src/Views/Core/Stage/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/Stage/index.blade.php
@@ -1,0 +1,93 @@
+@extends('behin-layouts.app')
+
+@section('title', 'گزارش مرحله‌ای درخواست‌ها')
+
+@section('content')
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-lg-12">
+                <div class="card mb-4 shadow-sm border-0">
+                    <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">فیلتر مراحل</h5>
+                        <span class="text-muted small">مراحل دارای درخواست باز</span>
+                    </div>
+                    <div class="card-body">
+                        <form method="GET" action="{{ route('simpleWorkflowReport.stage-report.index') }}">
+                            <div class="row g-3 align-items-end">
+                                <div class="col-md-9">
+                                    <label class="form-label">انتخاب مرحله (امکان انتخاب چند مرحله)</label>
+                                    <select name="tasks[]" class="form-select" multiple size="8">
+                                        @foreach ($tasks as $processId => $processTasks)
+                                            @php
+                                                $processName = $processTasks->first()?->process?->name ?? 'سایر فرایندها';
+                                            @endphp
+                                            <optgroup label="{{ $processName }}">
+                                                @foreach ($processTasks as $task)
+                                                    <option value="{{ $task->id }}" @selected(in_array($task->id, $selectedTasks))>
+                                                        {{ $task->name }}
+                                                    </option>
+                                                @endforeach
+                                            </optgroup>
+                                        @endforeach
+                                    </select>
+                                    <small class="text-muted d-block mt-2">برای انتخاب چند مرحله کلیدهای Ctrl یا Command را نگه دارید.</small>
+                                </div>
+                                <div class="col-md-3 d-flex gap-2 justify-content-md-end">
+                                    <button type="submit" class="btn btn-primary flex-grow-1">اعمال فیلتر</button>
+                                    <a href="{{ route('simpleWorkflowReport.stage-report.index') }}" class="btn btn-outline-secondary">حذف فیلتر</a>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="card shadow-sm border-0">
+                    <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">لیست درخواست‌ها</h5>
+                        <span class="badge bg-light text-primary">{{ $rows->count() }} مورد</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover align-middle">
+                                <thead class="table-light">
+                                <tr>
+                                    <th>شماره درخواست</th>
+                                    <th>نام مشتری</th>
+                                    <th>موبایل مشتری</th>
+                                    <th>کدملی</th>
+                                    <th>استان</th>
+                                    <th>پیمانکار</th>
+                                    <th>شناسه قبض</th>
+                                    <th>کدپستی</th>
+                                    <th>آدرس</th>
+                                    <th>مرحله جاری</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @forelse ($rows as $row)
+                                    <tr>
+                                        <td>{{ $row['case_number'] }}</td>
+                                        <td>{{ $row['customer_name'] ?? '---' }}</td>
+                                        <td dir="ltr">{{ $row['customer_mobile'] ?? '---' }}</td>
+                                        <td dir="ltr">{{ $row['customer_national_id'] ?? '---' }}</td>
+                                        <td>{{ $row['province'] ?? '---' }}</td>
+                                        <td>{{ $row['contractor'] ?? '---' }}</td>
+                                        <td dir="ltr">{{ $row['bill_identifier'] ?? '---' }}</td>
+                                        <td dir="ltr">{{ $row['postal_code'] ?? '---' }}</td>
+                                        <td>{{ $row['address'] ?? '---' }}</td>
+                                        <td>{{ $row['current_stage'] ?? '---' }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="10" class="text-center text-muted">رکوردی یافت نشد.</td>
+                                    </tr>
+                                @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection


### PR DESCRIPTION
## Summary
- update the stage report query to join case creators and read the mobile number from the creator email
- keep the existing customer mobile variable only as a fallback when no creator email is present

## Testing
- `php artisan test` *(fails: Carbon\CarbonPeriod constant type mismatch with bundled PHP version)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f953f0f083329b5a2e14fbd22a45