### PR TITLE
Add Excel export for stage report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/StageReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/StageReportController.php
@@ -4,16 +4,52 @@ namespace Behin\SimpleWorkflowReport\Controllers\Core;
 
 use App\Http\Controllers\Controller;
 use Behin\SimpleWorkflow\Models\Core\Task;
+use Behin\SimpleWorkflowReport\Exports\StageReportExport;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class StageReportController extends Controller
 {
+    protected array $openStatuses = ['new', 'opened', 'inProgress', 'draft'];
+
     public function index(Request $request): View
     {
-        $openStatuses = ['new', 'opened', 'inProgress', 'draft'];
+        $selectedTaskIds = $this->selectedTaskIds($request);
 
+        return view('SimpleWorkflowReportView::Core.Stage.index', [
+            'rows' => $this->fetchRows($selectedTaskIds),
+            'tasks' => $this->fetchTasks(),
+            'selectedTasks' => $selectedTaskIds,
+        ]);
+    }
+
+    public function export(Request $request): BinaryFileResponse
+    {
+        $selectedTaskIds = $this->selectedTaskIds($request);
+
+        return Excel::download(
+            new StageReportExport($this->fetchRows($selectedTaskIds)),
+            'stage-report.xlsx'
+        );
+    }
+
+    protected function selectedTaskIds(Request $request): array
+    {
+        $tasks = array_map(function ($value) {
+            return is_numeric($value) ? (int) $value : null;
+        }, (array) $request->input('tasks', []));
+
+        return array_values(array_filter($tasks, function ($value) {
+            return ! is_null($value);
+        }));
+    }
+
+    protected function fetchRows(array $selectedTaskIds): Collection
+    {
         $caseVariables = DB::table('wf_variables')
             ->select(
                 'case_id',
@@ -35,7 +71,7 @@ class StageReportController extends Controller
 
         $openCases = DB::table('wf_inbox')
             ->select('case_id', 'task_id')
-            ->whereIn('status', $openStatuses)
+            ->whereIn('status', $this->openStatuses)
             ->distinct();
 
         $query = DB::table('wf_cases as cases')
@@ -78,12 +114,11 @@ class StageReportController extends Controller
             ])
             ->orderByDesc('cases.created_at');
 
-        $selectedTaskIds = array_filter((array) $request->input('tasks', []));
         if (! empty($selectedTaskIds)) {
             $query->whereIn('open_cases.task_id', $selectedTaskIds);
         }
 
-        $rows = $query->get()->map(function ($row) {
+        return $query->get()->map(function ($row) {
             $nameCandidates = [
                 $row->customer_workshop_or_ceo_name,
                 $row->customer_fullname,
@@ -113,22 +148,19 @@ class StageReportController extends Controller
                 'current_stage' => $row->current_stage,
             ];
         })->values();
+    }
 
-        $tasks = Task::with('process')
-            ->whereIn('id', function ($query) use ($openStatuses) {
+    protected function fetchTasks(): Collection
+    {
+        return Task::with('process')
+            ->whereIn('id', function ($query) {
                 $query->select('task_id')
                     ->from('wf_inbox')
-                    ->whereIn('status', $openStatuses);
+                    ->whereIn('status', $this->openStatuses);
             })
             ->orderBy('process_id')
             ->orderBy('name')
             ->get()
             ->groupBy('process_id');
-
-        return view('SimpleWorkflowReportView::Core.Stage.index', [
-            'rows' => $rows,
-            'tasks' => $tasks,
-            'selectedTasks' => $selectedTaskIds,
-        ]);
     }
 }

--- a/packages/behin-simple-workflow-report/src/Exports/StageReportExport.php
+++ b/packages/behin-simple-workflow-report/src/Exports/StageReportExport.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Behin\SimpleWorkflowReport\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+class StageReportExport implements FromCollection, WithHeadings, WithMapping
+{
+    public function __construct(protected Collection $rows)
+    {
+    }
+
+    public function collection(): Collection
+    {
+        return $this->rows;
+    }
+
+    public function headings(): array
+    {
+        return [
+            'شماره درخواست',
+            'نام مشتری',
+            'موبایل مشتری',
+            'کدملی',
+            'استان',
+            'پیمانکار',
+            'شناسه قبض',
+            'کدپستی',
+            'آدرس',
+            'مرحله جاری',
+        ];
+    }
+
+    public function map($row): array
+    {
+        if ($row instanceof Collection) {
+            $row = $row->toArray();
+        } elseif (is_object($row)) {
+            $row = (array) $row;
+        }
+
+        return [
+            $row['case_number'] ?? null,
+            $row['customer_name'] ?? null,
+            $row['customer_mobile'] ?? null,
+            $row['customer_national_id'] ?? null,
+            $row['province'] ?? null,
+            $row['contractor'] ?? null,
+            $row['bill_identifier'] ?? null,
+            $row['postal_code'] ?? null,
+            $row['address'] ?? null,
+            $row['current_stage'] ?? null,
+        ];
+    }
+}

--- a/packages/behin-simple-workflow-report/src/Routes/web.php
+++ b/packages/behin-simple-workflow-report/src/Routes/web.php
@@ -22,13 +22,13 @@ use Behin\SimpleWorkflowReport\Controllers\Core\PhonebookController;
 use Behin\SimpleWorkflowReport\Controllers\Scripts\TotalTimeoff;
 use Behin\SimpleWorkflowReport\Controllers\Scripts\UserTimeoffs;
 use Illuminate\Support\Facades\Route;
-use Maatwebsite\Excel\Facades\Excel;
 
 Route::name('simpleWorkflowReport.')->prefix('workflow-report')->middleware(['web', 'auth'])->group(function () {
     Route::resource('summary-report', SummaryReportController::class);
 
     Route::resource('my-request', MyRequestController::class);
 
+    Route::get('stage-report/export', [StageReportController::class, 'export'])->name('stage-report.export');
     Route::get('stage-report', [StageReportController::class, 'index'])->name('stage-report.index');
 
 

--- a/packages/behin-simple-workflow-report/src/Views/Core/Stage/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/Stage/index.blade.php
@@ -42,9 +42,19 @@
                 </div>
 
                 <div class="card shadow-sm border-0">
-                    <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+                    <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center flex-wrap gap-2">
                         <h5 class="mb-0">لیست درخواست‌ها</h5>
-                        <span class="badge bg-light text-primary">{{ $rows->count() }} مورد</span>
+                        <div class="d-flex align-items-center gap-2 flex-wrap">
+                            <span class="badge bg-light text-primary">{{ $rows->count() }} مورد</span>
+                            <form method="GET" action="{{ route('simpleWorkflowReport.stage-report.export') }}">
+                                @foreach ($selectedTasks as $taskId)
+                                    <input type="hidden" name="tasks[]" value="{{ $taskId }}">
+                                @endforeach
+                                <button type="submit" class="btn btn-outline-light btn-sm">
+                                    خروجی اکسل
+                                </button>
+                            </form>
+                        </div>
                     </div>
                     <div class="card-body">
                         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- refactor the stage report controller to share row building logic and expose an Excel export action
- register an export route and add a UI button that forwards selected filters
- create a dedicated StageReportExport class to shape the spreadsheet output

## Testing
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/StageReportController.php
- php -l packages/behin-simple-workflow-report/src/Exports/StageReportExport.php

------
https://chatgpt.com/codex/tasks/task_e_68d10bb2cff88332843280a4deb961b4