### PR TITLE
Add preview workflow state for tasks

### DIFF
--- a/packages/behin-simple-workflow/src/Controllers/Core/ProcessController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/ProcessController.php
@@ -67,7 +67,7 @@ class ProcessController extends Controller
         $ar = [];
         foreach($processes as $process)
         {
-            $startTasks = TaskController::getProcessStartTasks($process->id);
+            $startTasks = TaskController::getProcessStartTasks($process->id, false);
             foreach($startTasks as $startTask)
             {
                 $result = TaskActorController::userIsAssignToTask($startTask->id, $userId);
@@ -92,6 +92,16 @@ class ProcessController extends Controller
     public static function start($taskId, $force = false, $redirect = true, $inDraft = false, $caseNumber = null, $creator = null, $parentId = null)
     {
         $task = TaskController::getById($taskId);
+        if (!$task) {
+            return response()->json([
+                'msg' => trans('fields.Task not found')
+            ], 404);
+        }
+        if ($task->is_preview) {
+            return response()->json([
+                'msg' => trans('fields.Task is in preview mode and cannot be started')
+            ], 403);
+        }
         if(!$force)
         {
             $listOfProcessThatUserCanStart = collect(self::listOfProcessThatUserCanStart(Auth::id()))->pluck('id')->toArray();
@@ -132,6 +142,9 @@ class ProcessController extends Controller
         $process = ProcessController::getById($processId);
         $hasError = 0;
         foreach($process->tasks() as $task){
+            if ($task->is_preview) {
+                continue;
+            }
             if(TaskController::TaskHasError($task->id)){
                 $hasError++;
             }

--- a/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
@@ -25,7 +25,9 @@ class TaskController extends Controller
 
     public function create(Request $request)
     {
-        $task = Task::create($request->all());
+        $data = $request->all();
+        $data['is_preview'] = true;
+        $task = Task::create($data);
         if (!$request->parent_id) {
             $task->parent_id = $task->id;
             $task->save();
@@ -41,7 +43,9 @@ class TaskController extends Controller
 
     public function update(Request $request, Task $task)
     {
-        $task->update($request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back', 'script_before_open', 'allow_cancel'));
+        $data = $request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back', 'script_before_open', 'allow_cancel', 'is_preview');
+        $data['is_preview'] = $request->boolean('is_preview');
+        $task->update($data);
         // self::getById($request->id)->update($request->all());
         return redirect()->back()->with('success', trans('Updated Successfully'));
     }
@@ -78,18 +82,41 @@ class TaskController extends Controller
         return Task::get();
     }
 
-    public static function getProcessTasks($process_id)
+    public static function getProcessTasks($process_id, $includePreview = true)
     {
-        return Task::where('process_id', $process_id)->get();
+        $query = Task::where('process_id', $process_id);
+        if (!$includePreview) {
+            $query->where(function ($subQuery) {
+                $subQuery->where('is_preview', false)
+                    ->orWhereNull('is_preview');
+            });
+        }
+
+        return $query->get();
     }
 
-    public static function getProcessStartTasks($process_id)
+    public static function getProcessStartTasks($process_id, $includePreview = true)
     {
-        return Task::where('process_id', $process_id)->whereColumn('id', 'parent_id')->get();
+        $query = Task::where('process_id', $process_id)->whereColumn('id', 'parent_id');
+
+        if (!$includePreview) {
+            $query->where(function ($subQuery) {
+                $subQuery->where('is_preview', false)
+                    ->orWhereNull('is_preview');
+            });
+        }
+
+        return $query->get();
     }
 
     public static function TaskHasError($taskId){
         $task = TaskController::getById($taskId);
+        if (!$task) {
+            return false;
+        }
+        if ($task->is_preview) {
+            return false;
+        }
         $hasError = 0;
         if($task->type == 'form'){
             // $hasError++;

--- a/packages/behin-simple-workflow/src/Lang/fa/fields.php
+++ b/packages/behin-simple-workflow/src/Lang/fa/fields.php
@@ -91,5 +91,12 @@ return [
     'Transfer cases to task' => 'انتقال کیس ها به تسک',
     'Task deleted successfully' => 'تسک با موفقیت حذف شد',
     'script_before_open' => 'اسکریپت قبل از باز شدن',
+    'Preview' => 'پیش‌نمایش',
+    'Preview Mode' => 'حالت پیش‌نمایش',
+    'Published' => 'منتشر شده',
+    'Preview Status' => 'وضعیت انتشار',
+    'Preview Status Hint' => 'تا زمان تبدیل وضعیت به منتشر شده، این تسک در جریان فرایند فعال نخواهد شد.',
+    'Task is in preview mode and cannot be started' => 'این تسک در حالت پیش‌نمایش است و امکان شروع آن وجود ندارد.',
+    'Task not found' => 'تسک یافت نشد',
 
 ];

--- a/packages/behin-simple-workflow/src/Migrations/2025_10_20_000000_add_is_preview_to_tasks_table.php
+++ b/packages/behin-simple-workflow/src/Migrations/2025_10_20_000000_add_is_preview_to_tasks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (!Schema::hasColumn('wf_task', 'is_preview')) {
+                $table->boolean('is_preview')->default(false)->after('assignment_type');
+            }
+        });
+
+        DB::table('wf_task')->whereNull('is_preview')->update(['is_preview' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (Schema::hasColumn('wf_task', 'is_preview')) {
+                $table->dropColumn('is_preview');
+            }
+        });
+    }
+};

--- a/packages/behin-simple-workflow/src/Models/Core/Process.php
+++ b/packages/behin-simple-workflow/src/Models/Core/Process.php
@@ -38,11 +38,11 @@ class Process extends Model
         return $this->hasMany(Cases::class);
     }
 
-    function tasks(){
-        return TaskController::getProcessTasks($this->id);
+    function tasks($includePreview = true){
+        return TaskController::getProcessTasks($this->id, $includePreview);
     }
 
-    function startTasks(){
-        return TaskController::getProcessStartTasks($this->id);
+    function startTasks($includePreview = true){
+        return TaskController::getProcessStartTasks($this->id, $includePreview);
     }
 }

--- a/packages/behin-simple-workflow/src/Models/Core/Task.php
+++ b/packages/behin-simple-workflow/src/Models/Core/Task.php
@@ -38,6 +38,7 @@ class Task extends Model
         'parent_id',
         'next_element_id',
         'assignment_type',
+        'is_preview',
         'case_name',
         'color',
         'background',
@@ -49,6 +50,10 @@ class Task extends Model
         'number_of_task_to_back',
         'script_before_open',
         'allow_cancel',
+    ];
+
+    protected $casts = [
+        'is_preview' => 'boolean',
     ];
 
     public function getStyledNameAttribute()

--- a/packages/behin-simple-workflow/src/Views/Core/Task/create.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/create.blade.php
@@ -144,7 +144,11 @@
                     <select name="parent_id" id="parent_id" class="form-select select2">
                         <option value="">{{ trans('None') }}</option>
                         @foreach ($process->tasks() as $task)
-                            <option value="{{ $task->id }}">{{ $task->name }}</option>
+                            <option value="{{ $task->id }}">{{ $task->name }}
+                                @if ($task->is_preview)
+                                    ({{ trans('fields.Preview') }})
+                                @endif
+                            </option>
                         @endforeach
                     </select>
                 </div>

--- a/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
@@ -311,7 +311,12 @@
                 <span class="material-icons material-header-icon">edit</span>
                 {{ $task->name }}
             </h5>
-            <span class="badge bg-{{ $bgColor }}">{{ ucfirst($task->type) }}</span>
+            <div class="d-flex align-items-center">
+                <span class="badge bg-{{ $bgColor }}">{{ ucfirst($task->type) }}</span>
+                <span class="badge {{ $task->is_preview ? 'bg-secondary text-dark ml-2' : 'bg-success ml-2' }}">
+                    {{ $task->is_preview ? trans('fields.Preview Mode') : trans('fields.Published') }}
+                </span>
+            </div>
         </div>
         <div class="card-body">
             <ul class="nav nav-tabs material-tabs" role="tablist">
@@ -353,6 +358,16 @@
                         </div>
                         <div class="col-md-6">
                             <div class="md-form-group">
+                                <label for="is_preview">{{ trans('fields.Preview Status') }}</label>
+                                <select name="is_preview" id="is_preview" class="form-control material-select">
+                                    <option value="1" {{ $task->is_preview ? 'selected' : '' }}>{{ trans('fields.Preview Mode') }}</option>
+                                    <option value="0" {{ !$task->is_preview ? 'selected' : '' }}>{{ trans('fields.Published') }}</option>
+                                </select>
+                                <small class="text-muted d-block mt-1">{{ trans('fields.Preview Status Hint') }}</small>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="md-form-group">
                                 <label for="parent_id">{{ trans('Parent Task') }}</label>
                                 <select name="parent_id" id="parent_id"
                                     class="form-control material-select select2">
@@ -360,7 +375,11 @@
                                     @foreach ($task->process->tasks() as $item)
                                         <option dir="ltr" value="{{ $item->id }}"
                                             {{ $item->id == $task->parent_id ? 'selected' : '' }}>
-                                            {{ $item->name }} ({{ $item->id }})
+                                            {{ $item->name }}
+                                            @if ($item->is_preview)
+                                                ({{ trans('fields.Preview') }})
+                                            @endif
+                                            ({{ $item->id }})
                                         </option>
                                     @endforeach
                                 </select>
@@ -376,6 +395,9 @@
                                         <option value="{{ $item->id }}"
                                             {{ $item->id == $task->next_element_id ? 'selected' : '' }}>
                                             {{ $item->name }}
+                                            @if ($item->is_preview)
+                                                ({{ trans('fields.Preview') }})
+                                            @endif
                                         </option>
                                     @endforeach
                                 </select>

--- a/packages/behin-simple-workflow/src/Views/Core/Task/tree.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/tree.blade.php
@@ -15,6 +15,9 @@
                     href="{{ route('simpleWorkflow.task.edit', $child->id) }}"><i class="fa fa-edit"></i></a>
             <strong class="">
                 <a data-toggle="collapse" href="#{{ $child->id }}">{{ $child->name }}</a>
+                @if ($child->is_preview)
+                    <span class="badge bg-secondary text-dark">{{ trans('fields.Preview') }}</span>
+                @endif
                 <span class="badge {{ $bgColor }}">
                     {{ ucfirst($child->type) }}
                 </span>

--- a/packages/behin-simple-workflow/src/Views/Core/Task/tree1.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/tree1.blade.php
@@ -18,7 +18,7 @@
 
     @endphp
     {{ $task->id }} --> {{ $child->id }}["<a type='submit' class="{{ $taskClass }} task-edit-link"
-        href='{{ route('simpleWorkflow.task.edit', $child->id) }}'>{{ $child->name }}</a>"]:::{{ $taskClass }}
+        href='{{ route('simpleWorkflow.task.edit', $child->id) }}'>{{ $child->name }}@if ($child->is_preview) ({{ trans('fields.Preview') }})@endif</a>"]:::{{ $taskClass }}
     @php
         $children = $child->children();
     @endphp


### PR DESCRIPTION
## Summary
- add an `is_preview` flag to workflow tasks with a migration and model cast so new tasks start in preview mode
- update task and process controllers to ignore preview tasks when starting processes or checking errors while letting editors toggle preview status
- surface preview status in task management views and translations so admins can promote tasks from preview to published

## Testing
- php artisan test *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE of type int)*

------
https://chatgpt.com/codex/tasks/task_e_68d15738bed083329d2fb55240d89295