### PR TITLE
Fix default task tab visibility

### DIFF
--- a/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
@@ -340,7 +340,7 @@
                 </li>
             </ul>
             <div class="tab-content material-tab-content">
-                <div role="tabpanel" class="tab-pane fade in active" id="tab-general">
+                <div role="tabpanel" class="tab-pane fade show active" id="tab-general">
                     <div class="row">
                         <div class="col-md-6">
                             <div class="md-form-group">


### PR DESCRIPTION
## Summary
- ensure the General tab content in the task editor is visible on initial load by using Bootstrap 4's `show` class

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d25d7566088332b6919faee550aa70