### PR TITLE
Add configurable inbox save button for tasks

### DIFF
--- a/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/TaskController.php
@@ -27,6 +27,7 @@ class TaskController extends Controller
     {
         $data = $request->all();
         $data['is_preview'] = true;
+        $data['show_save_button'] = $request->boolean('show_save_button');
         $task = Task::create($data);
         if (!$request->parent_id) {
             $task->parent_id = $task->id;
@@ -43,8 +44,9 @@ class TaskController extends Controller
 
     public function update(Request $request, Task $task)
     {
-        $data = $request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back', 'script_before_open', 'allow_cancel', 'is_preview');
+        $data = $request->only('name', 'executive_element_id', 'parent_id', 'next_element_id', 'assignment_type', 'case_name', 'color', 'background', 'duration', 'order', 'timing_type', 'timing_value', 'timing_key_name', 'number_of_task_to_back', 'script_before_open', 'allow_cancel', 'is_preview', 'show_save_button');
         $data['is_preview'] = $request->boolean('is_preview');
+        $data['show_save_button'] = $request->boolean('show_save_button');
         $task->update($data);
         // self::getById($request->id)->update($request->all());
         return redirect()->back()->with('success', trans('Updated Successfully'));

--- a/packages/behin-simple-workflow/src/Lang/fa/fields.php
+++ b/packages/behin-simple-workflow/src/Lang/fa/fields.php
@@ -98,5 +98,8 @@ return [
     'Preview Status Hint' => 'تا زمان تبدیل وضعیت به منتشر شده، این تسک در جریان فرایند فعال نخواهد شد.',
     'Task is in preview mode and cannot be started' => 'این تسک در حالت پیش‌نمایش است و امکان شروع آن وجود ندارد.',
     'Task not found' => 'تسک یافت نشد',
+    'Show Save Button' => 'نمایش دکمه ذخیره',
+    'Yes' => 'بله',
+    'No' => 'خیر',
 
 ];

--- a/packages/behin-simple-workflow/src/Migrations/2025_11_01_000000_add_show_save_button_to_tasks_table.php
+++ b/packages/behin-simple-workflow/src/Migrations/2025_11_01_000000_add_show_save_button_to_tasks_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (!Schema::hasColumn('wf_task', 'show_save_button')) {
+                $table->boolean('show_save_button')->default(false)->after('is_preview');
+            }
+        });
+
+        DB::table('wf_task')->whereNull('show_save_button')->update(['show_save_button' => false]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wf_task', function (Blueprint $table) {
+            if (Schema::hasColumn('wf_task', 'show_save_button')) {
+                $table->dropColumn('show_save_button');
+            }
+        });
+    }
+};

--- a/packages/behin-simple-workflow/src/Models/Core/Task.php
+++ b/packages/behin-simple-workflow/src/Models/Core/Task.php
@@ -39,6 +39,7 @@ class Task extends Model
         'next_element_id',
         'assignment_type',
         'is_preview',
+        'show_save_button',
         'case_name',
         'color',
         'background',
@@ -54,6 +55,7 @@ class Task extends Model
 
     protected $casts = [
         'is_preview' => 'boolean',
+        'show_save_button' => 'boolean',
     ];
 
     public function getStyledNameAttribute()

--- a/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
@@ -105,6 +105,13 @@
                     {{ trans('fields.Send Manully') }}
                 </button>
 
+                @if ($task->show_save_button)
+                    <button class="md-btn md-btn-primary" onclick="saveForm()">
+                        <i class="material-icons">save</i>
+                        {{ trans('fields.Save') }}
+                    </button>
+                @endif
+
                 <button class="md-btn md-btn-danger" onclick="saveAndNextForm()">
                     <i class="material-icons">save</i>
                     {{ trans('fields.Save and next') }}
@@ -160,6 +167,10 @@
             .md-btn-warning {
                 background-color: #FFC107;
                 color: #212121;
+            }
+
+            .md-btn-primary {
+                background-color: #3F51B5;
             }
 
             .md-btn-danger {

--- a/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Task/edit.blade.php
@@ -368,6 +368,15 @@
                         </div>
                         <div class="col-md-6">
                             <div class="md-form-group">
+                                <label for="show_save_button">{{ trans('fields.Show Save Button') }}</label>
+                                <select name="show_save_button" id="show_save_button" class="form-control material-select">
+                                    <option value="1" {{ $task->show_save_button ? 'selected' : '' }}>{{ trans('fields.Yes') }}</option>
+                                    <option value="0" {{ !$task->show_save_button ? 'selected' : '' }}>{{ trans('fields.No') }}</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="md-form-group">
                                 <label for="parent_id">{{ trans('Parent Task') }}</label>
                                 <select name="parent_id" id="parent_id"
                                     class="form-control material-select select2">


### PR DESCRIPTION
## Summary
- add a workflow task flag and migration for toggling the inbox save button
- expose the new option on the task edit screen with localized labels
- render the inbox save action when enabled alongside the existing buttons

## Testing
- php artisan test *(fails: Type of Carbon\CarbonPeriod::EXCLUDE_START_DATE must be compatible with DatePeriod::EXCLUDE_START_DATE)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f05598888332bf96f6bccd2183a6