### PR TITLE
Revamp login layout and harden OTP workflow

### DIFF
--- a/packages/behin-init/src/App/Http/Controllers/OtpLoginController.php
+++ b/packages/behin-init/src/App/Http/Controllers/OtpLoginController.php
@@ -5,24 +5,26 @@ namespace BehinInit\App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Behin\Sms\Controllers\SmsController;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 
 class OtpLoginController extends Controller
 {
-    public function view($phone, $error = null)
+    public function view(string $phone)
     {
-        return view('auth.verify-otp')->with(['phone' => $phone, 'error' => $error]);
+        $phone = convertPersianToEnglish($phone);
+
+        return view('auth.verify-otp')->with(['phone' => $phone]);
     }
 
-    public function send(Request $request)
+    public function send(Request $request): RedirectResponse
     {
         $request->validate([
             'phone' => ['required','string'],
         ]);
         $phone = convertPersianToEnglish($request->phone);
+
         $user = User::firstOrCreate(
             ['email' => $phone],
             [
@@ -43,31 +45,33 @@ class OtpLoginController extends Controller
             'value' => $otp
         ]);
         SmsController::sendByTemp($user->email, 755370, $params);
-        
-        return $this->view($user->email);
-        return response()->json(['message' => 'کد ارسال شد.']);
+
+        return redirect()->route('otp.view', ['phone' => $phone])->with('success', 'کد تأیید ارسال شد.');
     }
 
-    public function verify(Request $request)
+    public function verify(Request $request): RedirectResponse
     {
         $request->validate([
             'phone' => ['required','string'],
             'otp' => ['required','string'],
         ]);
 
+        $phone = convertPersianToEnglish($request->phone);
         $otp = convertPersianToEnglish($request->otp);
-        $user = User::where('email', $request->phone)->first();
-        if(!$user){
-            return $this->view($user->email, trans('auth.user not found'));
+
+        $user = User::where('email', $phone)->first();
+        if (! $user) {
+            return redirect()->route('otp.view', ['phone' => $phone])->with('error', trans('auth.user not found'));
         }
 
-        if ($user->reset_password_code == $otp) {
+        if ((string) $user->reset_password_code === (string) $otp) {
             $user->password = bcrypt(str()->random(12));
+            $user->reset_password_code = null;
             $user->save();
             Auth::login($user, true);
             return redirect()->route('admin.dashboard');
-            return view('admin.dashboard');
         }
-        return $this->view($user->email, 'کد نامعتبر یا منقضی است');
+
+        return redirect()->route('otp.view', ['phone' => $phone])->with('error', 'کد نامعتبر یا منقضی است');
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,166 +1,267 @@
-<!doctype html>
-<html lang="fa" dir="rtl">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>ستاپ — سامانه تأمین و اجرای پروژه‌های خورشیدی</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
-  <style>html,body{font-family: 'Vazirmatn', sans-serif;} .container{max-width:1200px;margin-inline:auto}</style>
-</head>
-<body class="bg-gray-50 text-gray-800">
-  <!-- Hero -->
-  <header class="bg-gradient-to-l from-yellow-400 via-yellow-300 to-amber-400 text-gray-900">
-    <div class="container px-6 py-12">
-      <div class="flex flex-col md:flex-row items-center gap-8">
-        <div class="flex-1">
-          <h1 class="text-3xl md:text-4xl font-bold mb-3">ستاپ — سامانه تأمین و اجرای پروژه‌های خورشیدی</h1>
-          <p class="mb-6 text-lg md:text-xl">ما متقاضیان نصب پنل خورشیدی را به پیمانکاران معتبر در سراسر ایران وصل می‌کنیم، تسهیلات مالی فراهم می‌کنیم و از آغاز تا تحویل پروژه همراه شما هستیم.</p>
-          <div class="flex flex-wrap gap-3">
-            <form id="send-otp-form" method="POST" action="{{ route('otp.send') }}" class="position-relative">
+@extends('behin-layouts.welcome')
 
-                @csrf
-                <input type="text" name="phone" class="form-control text-center" id="inputMobile" placeholder=" "
-                                required dir="ltr"
-                                autofocus
-                                inputmode="numeric">
-            </form>
-            <a href="#contact" class="inline-flex items-center gap-2 bg-gray-900 text-white px-4 py-2 rounded-lg shadow">درخواست مشاوره</a>
-            <a href="#how" class="inline-flex items-center gap-2 border border-gray-900 px-4 py-2 rounded-lg">بیشتر بدانید</a>
-          </div>
-          <!-- stats -->
-          <div class="mt-8 grid grid-cols-3 gap-4 md:grid-cols-3">
-            <div class="bg-white/70 p-4 rounded-lg text-center shadow">
-              <div class="text-sm">ظرفیت نصب‌شده</div>
-              <div class="text-2xl font-bold">۱.۷ مگاوات</div>
+@if (auth()->check())
+    <?php header('Location: https://s3tup.ir/admin'); ?>
+@endif
+
+@section('content')
+    <style>
+        body {
+            background: linear-gradient(135deg, #eeee23 0%, #2575fc 100%);
+            font-family: 'IRANSans', sans-serif;
+        }
+
+        .hero-section {
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 50px 20px;
+        }
+
+        .content-box {
+            color: #fff;
+        }
+
+        .content-box h1 {
+            font-size: 2rem;
+            font-weight: bold;
+        }
+
+        .features {
+            margin-top: 30px;
+        }
+
+        .feature-item {
+            margin-bottom: 15px;
+            display: flex;
+            align-items: center;
+        }
+
+        .feature-item i {
+            font-size: 22px;
+            margin-left: 10px;
+            color: #ffd700;
+        }
+
+        .login-card {
+            backdrop-filter: blur(15px);
+            background: rgba(255, 255, 255, 0.93);
+            border-radius: 20px;
+            box-shadow: 0 15px 35px rgba(0, 0, 0, 0.2);
+            transition: transform 0.3s ease-in-out;
+        }
+
+        .login-card:hover {
+            transform: translateY(-5px);
+        }
+
+        .form-control {
+            border: none;
+            border-bottom: 2px solid #ccc;
+            border-radius: 0;
+            background: transparent;
+            box-shadow: none !important;
+            transition: all 0.3s ease;
+        }
+
+        .form-control:focus {
+            border-bottom: 2px solid #2575fc;
+            outline: none;
+        }
+
+        .btn-gradient {
+            background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+            border: none;
+            color: #fff;
+            font-weight: bold;
+            border-radius: 12px;
+            transition: all 0.3s ease;
+        }
+
+        .btn-gradient:hover {
+            opacity: 0.9;
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(37, 117, 252, 0.3);
+        }
+
+        .floating-label {
+            position: absolute;
+            top: 12px;
+            right: 10px;
+            font-size: 14px;
+            color: #777;
+            transition: 0.3s;
+            pointer-events: none;
+        }
+
+        .form-control:focus + .floating-label,
+        .form-control:not(:placeholder-shown) + .floating-label {
+            top: -8px;
+            right: 0;
+            font-size: 12px;
+            color: #2575fc;
+        }
+
+        .login-tabs {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 8px;
+            margin-bottom: 20px;
+        }
+
+        .login-tabs button {
+            border: 0;
+            border-radius: 12px;
+            padding: 10px 0;
+            font-weight: 600;
+            color: #2575fc;
+            background: rgba(37, 117, 252, 0.08);
+            transition: all 0.3s ease;
+        }
+
+        .login-tabs button.active {
+            color: #fff;
+            background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+            box-shadow: 0 8px 20px rgba(37, 117, 252, 0.3);
+        }
+
+        .login-form {
+            display: none;
+        }
+
+        .login-form.active {
+            display: block;
+        }
+
+        .alert {
+            border-radius: 12px;
+        }
+    </style>
+
+    <div class="hero-section container">
+        <div class="row align-items-center">
+
+            <div class="col-lg-5 col-md-8 mx-auto">
+                <div class="card login-card p-4">
+                    <img src="{{ url('behin/logo.png') . '?' . config('app.version') }}" class="mb-4"
+                         style="max-height: 80px; margin: auto; " alt="Logo" width="100">
+                    <h4 class="text-center mb-4 fw-bold text-dark">ورود به حساب کاربری</h4>
+
+                    @if (session('status'))
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    @if ($errors->has('message'))
+                        <div class="alert alert-danger">
+                            {{ $errors->first('message') }}
+                        </div>
+                    @endif
+
+                    @php($initialTab = $errors->has('phone') ? 'otp-login' : 'password-login')
+                    <div class="login-tabs" data-initial-tab="{{ $initialTab }}">
+                        <button type="button" class="tab-trigger active" data-target="password-login">ورود با رمز عبور</button>
+                        <button type="button" class="tab-trigger" data-target="otp-login">دریافت کد یکبار مصرف</button>
+                    </div>
+
+                    <form method="POST" action="{{ route('login') }}" class="login-form active" id="password-login">
+                        @csrf
+                        <div class="mb-4 position-relative">
+                            <input type="text" name="email" class="form-control text-start" id="inputEmail"
+                                   placeholder=" " value="{{ old('email') }}" required dir="ltr" autocomplete="username">
+                            <label for="inputEmail" class="floating-label"><i class="fa fa-user me-1"></i> نام کاربری</label>
+                        </div>
+
+                        @error('email')
+                            <div class="alert alert-danger py-2">{{ $message }}</div>
+                        @enderror
+
+                        <div class="mb-4 position-relative">
+                            <input type="password" name="password" class="form-control text-start" id="inputPassword"
+                                   placeholder=" " required dir="ltr" autocomplete="current-password">
+                            <label for="inputPassword" class="floating-label"><i class="fa fa-lock me-1"></i> رمز عبور</label>
+                        </div>
+
+                        @error('password')
+                            <div class="alert alert-danger py-2">{{ $message }}</div>
+                        @enderror
+
+                        <button type="submit" class="btn btn-gradient w-100 py-3">ورود</button>
+                    </form>
+
+                    <form method="POST" action="{{ route('otp.send') }}" class="login-form" id="otp-login">
+                        @csrf
+
+                        <div class="mb-4 position-relative">
+                            <input type="text" name="phone" class="form-control text-center" id="inputMobile"
+                                   placeholder=" " required dir="ltr" inputmode="numeric" autocomplete="tel">
+                            <label for="inputMobile" class="floating-label"><i class="fa fa-phone me-1"></i> موبایل</label>
+                        </div>
+
+                        @error('phone')
+                            <div class="alert alert-danger py-2">{{ $message }}</div>
+                        @enderror
+
+                        <button type="submit" class="btn btn-gradient w-100 py-3">ارسال کد</button>
+                    </form>
+
+                    <div class="mt-4 text-center">
+                        @include('auth.partial.enamad-and-version')
+                    </div>
+                </div>
             </div>
-            <div class="bg-white/70 p-4 rounded-lg text-center shadow">
-              <div class="text-sm">پیمانکار در سراسر ایران</div>
-              <div class="text-2xl font-bold">بله</div>
+
+            <div class="col-lg-6 col-md-12 content-box text-center text-lg-start mb-5 mb-lg-0">
+                <h1>ستاپ</h1>
+                <h3 class="mb-3">سامانه تأمین و اجرای پروژه‌های خورشیدی</h3>
+                <p class="lead">ستاپ بستری نوین برای ثبت، پیگیری و اجرای پروژه‌های خورشیدی است.
+                    از ثبت درخواست تا اجرای کامل پروژه و دریافت گواهی‌های لازم، همه در یک سامانه.</p>
+
+                <div class="features text-start">
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> امکان ارائه تسهیلات مالی (وام)</div>
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> ثبت درخواست سریع و آنلاین</div>
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> نمایش پروژه‌ها به متخصصان استانی</div>
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> ثبت تجهیزات و قطعات مصرفی</div>
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> صدور گواهی تأیید بعد از نصب</div>
+                    <div class="feature-item"><i class="fa fa-check-circle"></i> پشتیبانی 24 ساعته: 02191017175</div>
+                </div>
             </div>
-            <div class="bg-white/70 p-4 rounded-lg text-center shadow">
-              <div class="text-sm">پروژه‌های تکمیل‌شده</div>
-              <div class="text-2xl font-bold">—</div>
-            </div>
-          </div>
         </div>
-        <div class="flex-1">
-          <div class="rounded-xl overflow-hidden shadow-lg bg-white">
-            <img src="https://images.unsplash.com/photo-1509395176047-4a66953fd231?q=80&w=1200&auto=format&fit=crop&ixlib=rb-4.0.3&s=placeholder" alt="پنل خورشیدی" class="w-full h-64 object-cover">
-            <div class="p-4">
-              <h3 class="font-bold mb-2">آغاز پروژه در ۳ مرحله ساده</h3>
-              <ol class="list-decimal pr-4 space-y-2 text-sm">
-                <li>درخواست آنلاین ثبت کنید</li>
-                <li>پیمانکار مناسب معرفی می‌شود</li>
-                <li>تأمین مالی و اجرای پروژه</li>
-              </ol>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
-  </header>
+@endsection
 
-  <main class="container px-6 py-12">
-    <!-- Features -->
-    <section class="mb-12">
-      <h2 class="text-2xl font-bold mb-4">ویژگی‌های اصلی ستاپ</h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div class="bg-white p-6 rounded-lg shadow">
-          <h4 class="font-semibold mb-2">شبکه گسترده پیمانکاران</h4>
-          <p class="text-sm">دسترسی به پیمانکاران معتبر و تایید‌شده در تمامی استان‌های ایران.</p>
-        </div>
-        <div class="bg-white p-6 rounded-lg shadow">
-          <h4 class="font-semibold mb-2">تسهیلات مالی</h4>
-          <p class="text-sm">امکان دریافت پیشنهادات مالی و تسهیلات برای نصب و راه‌اندازی نیروگاه.</p>
-        </div>
-        <div class="bg-white p-6 rounded-lg shadow">
-          <h4 class="font-semibold mb-2">پشتیبانی فنی و مدیریتی</h4>
-          <p class="text-sm">پیگیری پروژه از آغاز تا تحویل و تضمین کیفیت اجرا.</p>
-        </div>
-      </div>
-    </section>
+@section('script')
+    @parent
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const tabTriggers = document.querySelectorAll('.tab-trigger');
+            const forms = {
+                'password-login': document.getElementById('password-login'),
+                'otp-login': document.getElementById('otp-login')
+            };
+            const tabsContainer = document.querySelector('.login-tabs');
+            const initialTab = tabsContainer ? tabsContainer.dataset.initialTab : 'password-login';
 
-    <!-- How it works -->
-    <section id="how" class="mb-12">
-      <h2 class="text-2xl font-bold mb-4">نحوه کار</h2>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div class="p-6 bg-gradient-to-tr from-white to-gray-50 rounded-lg shadow">
-          <div class="text-xl font-bold mb-2">۱. ثبت درخواست</div>
-          <p class="text-sm">فرم کوتاه را پر کنید تا تیم ما نیاز شما را بررسی کند.</p>
-        </div>
-        <div class="p-6 bg-gradient-to-tr from-white to-gray-50 rounded-lg shadow">
-          <div class="text-xl font-bold mb-2">۲. انتخاب پیمانکار</div>
-          <p class="text-sm">پیمانکاران واجد شرایط با شما تماس می‌گیرند و پیشنهاد ارسال می‌کنند.</p>
-        </div>
-        <div class="p-6 bg-gradient-to-tr from-white to-gray-50 rounded-lg shadow">
-          <div class="text-xl font-bold mb-2">۳. اجرا و پشتیبانی</div>
-          <p class="text-sm">تامین مالی، اجرا و تست نهایی تا تحویل نهایی پروژه.</p>
-        </div>
-      </div>
-    </section>
+            tabTriggers.forEach(trigger => {
+                const isInitial = trigger.dataset.target === initialTab;
+                trigger.classList.toggle('active', isInitial);
+                if (forms[trigger.dataset.target]) {
+                    forms[trigger.dataset.target].classList.toggle('active', isInitial);
+                }
+            });
 
-    <!-- Map / contractors -->
-    {{-- <section class="mb-12">
-      <h2 class="text-2xl font-bold mb-4">پیمانکاران در سراسر ایران</h2>
-      <div class="bg-white rounded-lg shadow overflow-hidden p-6">
-        <div class="h-64 md:h-96 bg-gray-200 rounded-lg flex items-center justify-center">نقشه / ویجت نمایش پیمانکاران (قابل اتصال به گوگل مپز یا نقشه داخلی)</div>
-        <p class="text-sm mt-3">ما با شبکه‌ای از پیمانکاران در تمامی استان‌ها همکاری می‌کنیم — در هر شهر یک شریک محلی برای اجرا.</p>
-      </div>
-    </section> --}}
+            tabTriggers.forEach(trigger => {
+                trigger.addEventListener('click', () => {
+                    const target = trigger.dataset.target;
+                    tabTriggers.forEach(btn => btn.classList.toggle('active', btn === trigger));
 
-    <!-- Testimonials / numbers -->
-    {{-- <section class="mb-12 grid grid-cols-1 md:grid-cols-2 gap-6">
-      <div class="bg-white p-6 rounded-lg shadow">
-        <h3 class="font-bold mb-2">اعداد و واقعیت‌ها</h3>
-        <ul class="space-y-3 text-sm">
-          <li>ظرفیت نصب‌شده: <strong>۱.۷ مگاوات</strong></li>
-          <li>پیمانکاران فعال: <strong>در سراسر ایران</strong></li>
-          <li>پروژه‌های موفق: <strong>در حال افزایش</strong></li>
-        </ul>
-      </div>
-      <div class="bg-white p-6 rounded-lg shadow">
-        <h3 class="font-bold mb-2">نظرات مشتریان</h3>
-        <blockquote class="text-sm italic">"اجرای پروژه ما سریع و دقیق انجام شد — از تیم ستاپ ممنونیم." — مشتری نمونه</blockquote>
-      </div>
-    </section> --}}
-
-    <!-- Contact / CTA form -->
-    {{-- <section id="contact" class="mb-12 bg-white p-6 rounded-lg shadow">
-      <h2 class="text-2xl font-bold mb-4">درخواست مشاوره</h2>
-      <form class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <input placeholder="نام و نام خانوادگی" class="p-3 border rounded" />
-        <input placeholder="شماره تماس" class="p-3 border rounded" />
-        <input placeholder="شهر" class="p-3 border rounded" />
-        <select class="p-3 border rounded">
-          <option>نوع درخواست: نصب خانگی</option>
-          <option>نوع درخواست: نصب تجاری</option>
-        </select>
-        <textarea placeholder="توضیحات کوتاه (اختیاری)" class="p-3 border rounded md:col-span-2"></textarea>
-        <div class="md:col-span-2 flex justify-start">
-          <button type="submit" class="px-6 py-2 bg-amber-500 rounded-lg text-white font-semibold">ارسال درخواست</button>
-        </div>
-      </form>
-    </section> --}}
-
-  </main>
-
-  <footer class="bg-gray-900 text-white py-8">
-    <div class="container px-6">
-      <div class="flex flex-col md:flex-row justify-between items-start gap-6">
-        <div>
-          <h4 class="font-bold mb-2">ستاپ</h4>
-          <p class="text-sm">سامانه تأمین و اجرای پروژه‌های خورشیدی — اتصال متقاضیان به پیمانکاران و ارائه تسهیلات مالی.</p>
-        </div>
-        <div>
-          <h5 class="font-semibold mb-2">تماس</h5>
-          <p class="text-sm">ایمیل: info@setap.example</p>
-          <p class="text-sm">تلفن: ۰۲۱-xxxxxxx</p>
-        </div>
-      </div>
-      <div class="text-sm text-gray-400 mt-6">© تمامی حقوق برای ستاپ محفوظ است.</div>
-    </div>
-  </footer>
-
-</body>
-</html>
+                    Object.keys(forms).forEach(key => {
+                        forms[key].classList.toggle('active', key === target);
+                    });
+                });
+            });
+        });
+    </script>
+@endsection

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -26,7 +26,7 @@ Route::middleware('guest')->group(function () {
     Route::post('login', [LoginController::class, 'store']);
 
     Route::post('otp/send', [OtpLoginController::class, 'send'])->name('otp.send');
-    Route::get('otp/send', [OtpLoginController::class, 'view'])->name('otp.view');
+    Route::get('otp/send/{phone}', [OtpLoginController::class, 'view'])->name('otp.view');
     Route::post('otp/verify', [OtpLoginController::class, 'verify'])->name('otp.verify');
 });
 


### PR DESCRIPTION
## Summary
- restyle the login page within the existing welcome layout and add tabbed password/OTP forms that match the landing design
- improve validation and messaging for the login forms while keeping existing compliance widgets visible
- sanitize phone numbers, redirect with session feedback, and clear codes in the OTP controller while updating the OTP route signature

## Testing
- php artisan test *(fails: vendor CarbonPeriod definition incompatible with DatePeriod::EXCLUDE_START_DATE)*

------
https://chatgpt.com/codex/tasks/task_e_68d816472d408332b9a3eb5bb9bea3c4