### PR TITLE
Adjust login and OTP form widths to match stats layout

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -22,7 +22,7 @@
         id="login-form"
         method="POST"
         action="{{ route('otp.send') }}"
-        class="flex flex-col sm:flex-row sm:items-center gap-2 bg-white p-3 rounded-lg shadow w-full max-w-xl"
+        class="flex flex-col sm:flex-row sm:items-center gap-2 bg-white p-3 rounded-lg shadow w-full"
       >
         @csrf
         <input

--- a/resources/views/auth/verify-otp.blade.php
+++ b/resources/views/auth/verify-otp.blade.php
@@ -16,7 +16,7 @@
         <div class="flex-1">
           <h1 class="text-3xl md:text-4xl font-bold mb-3">کد تأیید برای ورود به ستاپ</h1>
           <p class="mb-6 text-lg md:text-xl">برای ادامه ورود به سامانه، کد یکبار مصرف ارسال‌شده به شماره ثبت‌شده را وارد کنید.</p>
-          <div class="flex flex-col gap-4 bg-white/80 p-6 rounded-xl shadow w-full max-w-md">
+          <div class="flex flex-col gap-4 bg-white/80 p-6 rounded-xl shadow w-full">
             <div class="space-y-2">
               @if (session('success'))
                 <div class="rounded-lg bg-green-100 text-green-800 px-4 py-3 text-sm">{{ session('success') }}</div>


### PR DESCRIPTION
## Summary
- remove the fixed max-width from the login and verify OTP forms so they fill the full column width and align with the stat/info boxes below

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d824b4c9a8833295b6b514878cab66