### PR TITLE
Add pagination and advanced filtering to all requests report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -3,21 +3,31 @@
 namespace Behin\SimpleWorkflowReport\Controllers\Core;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 class AllRequestsReportController extends Controller
 {
-    public function index(): View
+    public function index(Request $request): View
     {
+        $filters = $request->except('page');
+        $perPage = (int) ($filters['per_page'] ?? 15);
+
         return view('SimpleWorkflowReportView::Core.AllRequests.index', [
-            'rows' => $this->fetchRows(),
+            'rows' => $this->fetchRows($filters, $perPage),
+            'filters' => $filters,
+            'perPage' => $perPage,
         ]);
     }
 
-    protected function fetchRows(): Collection
+    protected function fetchRows(array $filters, int $perPage = 15): LengthAwarePaginator
     {
+        $perPage = $this->resolvePerPage($perPage);
+        $filters = Arr::except($filters, ['per_page']);
+
         $caseVariables = DB::table('wf_variables')
             ->select(
                 'case_id',
@@ -59,10 +69,10 @@ class AllRequestsReportController extends Controller
                 'inbox.case_id',
                 'inbox.status as inbox_status',
                 'tasks.name as task_name',
-                // 'tasks.styled_name as task_styled_name'
+                'tasks.styled_name as task_styled_name'
             );
 
-        return DB::table('wf_cases as cases')
+        $query = DB::table('wf_cases as cases')
             ->leftJoinSub($caseVariables, 'vars', function ($join) {
                 $join->on('cases.id', '=', 'vars.case_id');
             })
@@ -85,31 +95,115 @@ class AllRequestsReportController extends Controller
                 'cases.status as case_status',
                 'last_status.inbox_status',
                 'last_status.task_name',
-                // 'last_status.task_styled_name'
+                'last_status.task_styled_name',
+                DB::raw('COALESCE(last_status.task_styled_name, last_status.task_name, last_status.inbox_status, cases.status) as last_status')
             ])
-            ->orderByDesc('cases.created_at')
-            ->get()
-            ->map(function ($row) {
-                $lastStatus = trim(strip_tags($row->task_styled_name ?? $row->task_name ?? ''));
+            ->orderByDesc('cases.created_at');
+
+        $query = $this->applyFilters($query, $filters);
+
+        $appendFilters = array_filter($filters, function ($value) {
+            return $value !== null && $value !== '';
+        });
+
+        $appendFilters['per_page'] = $perPage;
+
+        $paginator = $query->paginate($perPage)->appends($appendFilters);
+
+        $paginator->setCollection(
+            $paginator->getCollection()->map(function ($row) {
+                $lastStatus = trim(strip_tags($row->last_status ?? ''));
 
                 if ($lastStatus === '') {
-                    $lastStatus = $row->inbox_status ?? $row->case_status;
+                    $lastStatus = $row->inbox_status ?? $row->case_status ?? null;
                 }
 
-                return [
-                    'case_number' => $row->case_number,
-                    'user_firstname' => $row->user_firstname,
-                    'user_lastname' => $row->user_lastname,
-                    'electricity_bill_id' => $row->electricity_bill_id,
-                    'powerhouse_type' => $row->powerhouse_type,
-                    'powerhouse_province' => $row->powerhouse_province,
-                    'requested_capacity_of_powerhouse' => $row->requested_capacity_of_powerhouse,
-                    'first_call_result' => $row->first_call_result,
-                    'loan_interest' => $row->loan_interest,
-                    'initial_amount' => $row->initial_amount,
-                    'feasibility_study' => $row->feasibility_study,
-                    'last_status' => $lastStatus,
-                ];
+                $row->last_status = $lastStatus;
+
+                return $row;
+            })
+        );
+
+        return $paginator;
+    }
+
+    protected function resolvePerPage(int $perPage): int
+    {
+        $allowed = [10, 15, 25, 50, 100];
+
+        if (!in_array($perPage, $allowed, true)) {
+            $perPage = 15;
+        }
+
+        return $perPage;
+    }
+
+    protected function applyFilters($query, array $filters)
+    {
+        foreach ($filters as $key => $value) {
+            if ($value === null || $value === '') {
+                unset($filters[$key]);
+            }
+        }
+
+        if (!empty($filters['case_number'])) {
+            $query->where('cases.number', 'like', '%' . $filters['case_number'] . '%');
+        }
+
+        if (!empty($filters['user_firstname'])) {
+            $query->where('vars.user_firstname', 'like', '%' . $filters['user_firstname'] . '%');
+        }
+
+        if (!empty($filters['user_lastname'])) {
+            $query->where('vars.user_lastname', 'like', '%' . $filters['user_lastname'] . '%');
+        }
+
+        if (!empty($filters['electricity_bill_id'])) {
+            $query->where('vars.electricity_bill_id', 'like', '%' . $filters['electricity_bill_id'] . '%');
+        }
+
+        if (!empty($filters['powerhouse_type'])) {
+            $query->where('vars.powerhouse_type', 'like', '%' . $filters['powerhouse_type'] . '%');
+        }
+
+        if (!empty($filters['powerhouse_province'])) {
+            $query->where(function ($subQuery) use ($filters) {
+                $subQuery
+                    ->where('vars.powerhouse_place_info_province', 'like', '%' . $filters['powerhouse_province'] . '%')
+                    ->orWhere('place.province', 'like', '%' . $filters['powerhouse_province'] . '%');
             });
+        }
+
+        if (!empty($filters['requested_capacity_of_powerhouse'])) {
+            $query->where('vars.requested_capacity_of_powerhouse', 'like', '%' . $filters['requested_capacity_of_powerhouse'] . '%');
+        }
+
+        if (!empty($filters['first_call_result'])) {
+            $query->where('vars.first_call_result', 'like', '%' . $filters['first_call_result'] . '%');
+        }
+
+        if (!empty($filters['loan_interest'])) {
+            $query->where('vars.loan_interest', 'like', '%' . $filters['loan_interest'] . '%');
+        }
+
+        if (!empty($filters['initial_amount'])) {
+            $query->where('vars.initial_amount', 'like', '%' . $filters['initial_amount'] . '%');
+        }
+
+        if (!empty($filters['feasibility_study'])) {
+            $query->where('vars.feasibility_study', 'like', '%' . $filters['feasibility_study'] . '%');
+        }
+
+        if (!empty($filters['last_status'])) {
+            $query->where(function ($subQuery) use ($filters) {
+                $subQuery
+                    ->where('last_status.task_styled_name', 'like', '%' . $filters['last_status'] . '%')
+                    ->orWhere('last_status.task_name', 'like', '%' . $filters['last_status'] . '%')
+                    ->orWhere('last_status.inbox_status', 'like', '%' . $filters['last_status'] . '%')
+                    ->orWhere('cases.status', 'like', '%' . $filters['last_status'] . '%');
+            });
+        }
+
+        return $query;
     }
 }

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
@@ -9,9 +9,89 @@
                 <div class="card shadow-sm border-0">
                     <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center flex-wrap gap-2">
                         <h5 class="mb-0">لیست تمام درخواست‌ها</h5>
-                        <span class="badge bg-light text-primary">{{ $rows->count() }} مورد</span>
+                        <span class="badge bg-light text-primary">{{ number_format($rows->total()) }} مورد</span>
                     </div>
                     <div class="card-body">
+                        @php
+                            $filters = $filters ?? [];
+                            $hasActiveFilters = collect($filters)->except(['per_page'])->filter(fn($value) => $value !== null && $value !== '')->isNotEmpty();
+                        @endphp
+
+                        <div class="mb-3">
+                            <button class="btn btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#advanced-filters" aria-expanded="{{ $hasActiveFilters ? 'true' : 'false' }}" aria-controls="advanced-filters">
+                                فیلتر پیشرفته
+                            </button>
+                        </div>
+
+                        <div class="collapse {{ $hasActiveFilters ? 'show' : '' }}" id="advanced-filters">
+                            <div class="card card-body border-0 shadow-sm mb-4">
+                                <form method="GET" action="{{ route('all-requests.index') }}">
+                                    <div class="row g-3">
+                                        <div class="col-md-3">
+                                            <label class="form-label">شماره پرونده</label>
+                                            <input type="text" name="case_number" value="{{ $filters['case_number'] ?? '' }}" class="form-control" placeholder="مثال: 1234">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">نام</label>
+                                            <input type="text" name="user_firstname" value="{{ $filters['user_firstname'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">نام خانوادگی</label>
+                                            <input type="text" name="user_lastname" value="{{ $filters['user_lastname'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">شناسه قبض برق</label>
+                                            <input type="text" name="electricity_bill_id" value="{{ $filters['electricity_bill_id'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">نوع نیروگاه</label>
+                                            <input type="text" name="powerhouse_type" value="{{ $filters['powerhouse_type'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">استان محل نیروگاه</label>
+                                            <input type="text" name="powerhouse_province" value="{{ $filters['powerhouse_province'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">ظرفیت درخواستی</label>
+                                            <input type="text" name="requested_capacity_of_powerhouse" value="{{ $filters['requested_capacity_of_powerhouse'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">نتیجه اولین تماس</label>
+                                            <input type="text" name="first_call_result" value="{{ $filters['first_call_result'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">سود تسهیلات</label>
+                                            <input type="text" name="loan_interest" value="{{ $filters['loan_interest'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">مبلغ اولیه</label>
+                                            <input type="text" name="initial_amount" value="{{ $filters['initial_amount'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">امکان‌سنجی</label>
+                                            <input type="text" name="feasibility_study" value="{{ $filters['feasibility_study'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">آخرین وضعیت درخواست</label>
+                                            <input type="text" name="last_status" value="{{ $filters['last_status'] ?? '' }}" class="form-control">
+                                        </div>
+                                        <div class="col-md-3">
+                                            <label class="form-label">تعداد نمایش در هر صفحه</label>
+                                            <select name="per_page" class="form-select">
+                                                @foreach([10, 15, 25, 50, 100] as $size)
+                                                    <option value="{{ $size }}" {{ ($perPage ?? 15) == $size ? 'selected' : '' }}>{{ $size }}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex justify-content-end gap-2 mt-4">
+                                        <a href="{{ route('all-requests.index') }}" class="btn btn-light">پاکسازی فیلتر</a>
+                                        <button type="submit" class="btn btn-primary">اعمال فیلتر</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+
                         <div class="table-responsive">
                             <table class="table table-striped table-hover align-middle">
                                 <thead class="table-light">
@@ -33,18 +113,18 @@
                                 <tbody>
                                 @forelse($rows as $row)
                                     <tr>
-                                        <td>{{ $row['case_number'] ?? '---' }}</td>
-                                        <td>{{ $row['user_firstname'] ?? '---' }}</td>
-                                        <td>{{ $row['user_lastname'] ?? '---' }}</td>
-                                        <td dir="ltr">{{ $row['electricity_bill_id'] ?? '---' }}</td>
-                                        <td>{{ $row['powerhouse_type'] ?? '---' }}</td>
-                                        <td>{{ $row['powerhouse_province'] ?? '---' }}</td>
-                                        <td>{{ $row['requested_capacity_of_powerhouse'] ?? '---' }}</td>
-                                        <td>{{ $row['first_call_result'] ?? '---' }}</td>
-                                        <td>{{ $row['loan_interest'] ?? '---' }}</td>
-                                        <td>{{ $row['initial_amount'] ?? '---' }}</td>
-                                        <td>{{ $row['feasibility_study'] ?? '---' }}</td>
-                                        <td>{{ $row['last_status'] ?? '---' }}</td>
+                                        <td>{{ $row->case_number ?? '---' }}</td>
+                                        <td>{{ $row->user_firstname ?? '---' }}</td>
+                                        <td>{{ $row->user_lastname ?? '---' }}</td>
+                                        <td dir="ltr">{{ $row->electricity_bill_id ?? '---' }}</td>
+                                        <td>{{ $row->powerhouse_type ?? '---' }}</td>
+                                        <td>{{ $row->powerhouse_province ?? '---' }}</td>
+                                        <td>{{ $row->requested_capacity_of_powerhouse ?? '---' }}</td>
+                                        <td>{{ $row->first_call_result ?? '---' }}</td>
+                                        <td>{{ $row->loan_interest ?? '---' }}</td>
+                                        <td>{{ $row->initial_amount ?? '---' }}</td>
+                                        <td>{{ $row->feasibility_study ?? '---' }}</td>
+                                        <td>{{ $row->last_status ?? '---' }}</td>
                                     </tr>
                                 @empty
                                     <tr>
@@ -53,6 +133,15 @@
                                 @endforelse
                                 </tbody>
                             </table>
+                        </div>
+
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-3">
+                            <div class="text-muted small">
+                                نمایش {{ $rows->firstItem() ?? 0 }} تا {{ $rows->lastItem() ?? 0 }} از {{ number_format($rows->total()) }} رکورد
+                            </div>
+                            <div>
+                                {{ $rows->onEachSide(1)->links() }}
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add server-side pagination with configurable page size and sanitized last-status handling in the all requests controller
- introduce advanced filter processing across all report columns
- update the Blade view with a collapsible advanced filter form, pagination controls, and per-page selector

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ac603bfc8332a4abbb30932a9e2a