### PR TITLE
Fix pagination controls and advanced filter toggle in workflow report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
@@ -18,7 +18,7 @@
                         @endphp
 
                         <div class="mb-3">
-                            <button class="btn btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#advanced-filters" aria-expanded="{{ $hasActiveFilters ? 'true' : 'false' }}" aria-controls="advanced-filters">
+                            <button class="btn btn-outline-primary" type="button" data-toggle="collapse" data-target="#advanced-filters" aria-expanded="{{ $hasActiveFilters ? 'true' : 'false' }}" aria-controls="advanced-filters">
                                 فیلتر پیشرفته
                             </button>
                         </div>
@@ -140,7 +140,7 @@
                                 نمایش {{ $rows->firstItem() ?? 0 }} تا {{ $rows->lastItem() ?? 0 }} از {{ number_format($rows->total()) }} رکورد
                             </div>
                             <div>
-                                {{ $rows->onEachSide(1)->links() }}
+                                {{ $rows->onEachSide(1)->links('pagination::bootstrap-4') }}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- switch the advanced filter button to Bootstrap 4 collapse attributes so it toggles correctly
- render the all requests pagination links with the Bootstrap 4 view to restore proper styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ef5791508332853a645b3872ce75