### PR TITLE
Add Excel export and improve last status reporting for all requests report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -7,11 +7,17 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Maatwebsite\Excel\Facades\Excel;
+use Behin\SimpleWorkflowReport\Exports\AllRequestsReportExport;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class AllRequestsReportController extends Controller
 {
+    protected array $openStatuses = ['new', 'opened', 'inProgress', 'draft'];
+
     public function index(Request $request): View
     {
         $filters = $request->except('page');
@@ -24,11 +30,47 @@ class AllRequestsReportController extends Controller
         ]);
     }
 
+    public function export(Request $request): BinaryFileResponse
+    {
+        $filters = $request->except('page');
+
+        $rows = $this->prepareRows(
+            $this->baseQuery($filters)->get()
+        );
+
+        return Excel::download(
+            new AllRequestsReportExport($rows),
+            'all-requests-report.xlsx'
+        );
+    }
+
     protected function fetchRows(array $filters, int $perPage = 15): LengthAwarePaginator
     {
         $perPage = $this->resolvePerPage($perPage);
+
+        $query = $this->baseQuery($filters);
+
         $filters = Arr::except($filters, ['per_page']);
 
+        $query = $this->applyFilters($query, $filters);
+
+        $appendFilters = array_filter($filters, function ($value) {
+            return $value !== null && $value !== '';
+        });
+
+        $appendFilters['per_page'] = $perPage;
+
+        $paginator = $query->paginate($perPage)->appends($appendFilters);
+
+        $paginator->setCollection(
+            $this->prepareRows($paginator->getCollection())
+        );
+
+        return $paginator;
+    }
+
+    protected function baseQuery(array $filters)
+    {
         $caseVariables = DB::table('wf_variables')
             ->select(
                 'case_id',
@@ -77,13 +119,25 @@ class AllRequestsReportController extends Controller
                 DB::raw($taskStyledNameColumn . ' as task_styled_name')
             );
 
-        $query = DB::table('wf_cases as cases')
+        $activeStatuses = DB::table('wf_inbox as inbox')
+            ->leftJoin('wf_task as tasks', 'tasks.id', '=', 'inbox.task_id')
+            ->select(
+                'inbox.case_id',
+                DB::raw("GROUP_CONCAT(DISTINCT COALESCE($taskStyledNameColumn, tasks.name, inbox.status) ORDER BY inbox.id SEPARATOR '|||') as active_statuses")
+            )
+            ->whereIn('inbox.status', $this->openStatuses)
+            ->groupBy('inbox.case_id');
+
+        return DB::table('wf_cases as cases')
             ->leftJoinSub($caseVariables, 'vars', function ($join) {
                 $join->on('cases.id', '=', 'vars.case_id');
             })
             ->leftJoin('wf_entity_powerhouse_place_info as place', 'place.id', '=', 'vars.powerhouse_place_info_id')
             ->leftJoinSub($lastStatuses, 'last_status', function ($join) {
                 $join->on('cases.id', '=', 'last_status.case_id');
+            })
+            ->leftJoinSub($activeStatuses, 'active_statuses', function ($join) {
+                $join->on('cases.id', '=', 'active_statuses.case_id');
             })
             ->select([
                 'cases.number as case_number',
@@ -101,22 +155,20 @@ class AllRequestsReportController extends Controller
                 'last_status.inbox_status',
                 'last_status.task_name',
                 'last_status.task_styled_name',
+                'active_statuses.active_statuses',
                 DB::raw('COALESCE(last_status.task_styled_name, last_status.task_name, last_status.inbox_status, cases.status) as last_status')
             ])
             ->orderByDesc('cases.created_at');
+    }
 
-        $query = $this->applyFilters($query, $filters);
+    protected function prepareRows(Collection $rows): Collection
+    {
+        return $rows->map(function ($row) {
+            $activeStatuses = $this->extractStatuses($row->active_statuses ?? null);
 
-        $appendFilters = array_filter($filters, function ($value) {
-            return $value !== null && $value !== '';
-        });
-
-        $appendFilters['per_page'] = $perPage;
-
-        $paginator = $query->paginate($perPage)->appends($appendFilters);
-
-        $paginator->setCollection(
-            $paginator->getCollection()->map(function ($row) {
+            if ($activeStatuses->isNotEmpty()) {
+                $row->last_status = $activeStatuses->implode('، ');
+            } else {
                 $lastStatus = trim(strip_tags($row->last_status ?? ''));
 
                 if ($lastStatus === '') {
@@ -124,12 +176,29 @@ class AllRequestsReportController extends Controller
                 }
 
                 $row->last_status = $lastStatus;
+            }
 
-                return $row;
+            unset($row->active_statuses);
+
+            return $row;
+        });
+    }
+
+    protected function extractStatuses(?string $rawStatuses): Collection
+    {
+        if (! $rawStatuses) {
+            return collect();
+        }
+
+        return collect(explode('|||', $rawStatuses))
+            ->map(function ($value) {
+                $value = trim(strip_tags($value ?? ''));
+
+                return $value === '' ? null : $value;
             })
-        );
-
-        return $paginator;
+            ->filter()
+            ->unique()
+            ->values();
     }
 
     protected function resolvePerPage(int $perPage): int
@@ -201,11 +270,14 @@ class AllRequestsReportController extends Controller
 
         if (!empty($filters['last_status'])) {
             $query->where(function ($subQuery) use ($filters) {
+                $value = '%' . $filters['last_status'] . '%';
+
                 $subQuery
-                    ->where('last_status.task_styled_name', 'like', '%' . $filters['last_status'] . '%')
-                    ->orWhere('last_status.task_name', 'like', '%' . $filters['last_status'] . '%')
-                    ->orWhere('last_status.inbox_status', 'like', '%' . $filters['last_status'] . '%')
-                    ->orWhere('cases.status', 'like', '%' . $filters['last_status'] . '%');
+                    ->where('last_status.task_styled_name', 'like', $value)
+                    ->orWhere('last_status.task_name', 'like', $value)
+                    ->orWhere('last_status.inbox_status', 'like', $value)
+                    ->orWhere('cases.status', 'like', $value)
+                    ->orWhere('active_statuses.active_statuses', 'like', $value);
             });
         }
 

--- a/packages/behin-simple-workflow-report/src/Exports/AllRequestsReportExport.php
+++ b/packages/behin-simple-workflow-report/src/Exports/AllRequestsReportExport.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Behin\SimpleWorkflowReport\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+
+class AllRequestsReportExport implements FromCollection, WithHeadings, WithMapping
+{
+    public function __construct(protected Collection $rows)
+    {
+    }
+
+    public function collection(): Collection
+    {
+        return $this->rows;
+    }
+
+    public function headings(): array
+    {
+        return [
+            'شماره پرونده',
+            'نام',
+            'نام خانوادگی',
+            'شناسه قبض برق',
+            'نوع نیروگاه',
+            'استان محل نیروگاه',
+            'ظرفیت درخواستی',
+            'نتیجه اولین تماس',
+            'سود تسهیلات',
+            'مبلغ اولیه',
+            'امکان‌سنجی',
+            'آخرین وضعیت درخواست',
+        ];
+    }
+
+    public function map($row): array
+    {
+        if ($row instanceof Collection) {
+            $row = $row->toArray();
+        } elseif (is_object($row)) {
+            $row = (array) $row;
+        }
+
+        return [
+            $row['case_number'] ?? null,
+            $row['user_firstname'] ?? null,
+            $row['user_lastname'] ?? null,
+            $row['electricity_bill_id'] ?? null,
+            $row['powerhouse_type'] ?? null,
+            $row['powerhouse_province'] ?? null,
+            $row['requested_capacity_of_powerhouse'] ?? null,
+            $row['first_call_result'] ?? null,
+            $row['loan_interest'] ?? null,
+            $row['initial_amount'] ?? null,
+            $row['feasibility_study'] ?? null,
+            $row['last_status'] ?? null,
+        ];
+    }
+}

--- a/packages/behin-simple-workflow-report/src/Routes/web.php
+++ b/packages/behin-simple-workflow-report/src/Routes/web.php
@@ -30,6 +30,7 @@ Route::name('simpleWorkflowReport.')->prefix('workflow-report')->middleware(['we
 
     Route::resource('my-request', MyRequestController::class);
 
+    Route::get('all-requests/export', [AllRequestsReportController::class, 'export'])->middleware(Access::class. ':گزارش کل درخواست های ثبت شده')->name('all-requests.export');
     Route::get('all-requests', [AllRequestsReportController::class, 'index'])->middleware(Access::class. ':گزارش کل درخواست های ثبت شده')->name('all-requests.index');
 
     Route::get('stage-report/export', [StageReportController::class, 'export'])->name('stage-report.export');

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
@@ -9,7 +9,18 @@
                 <div class="card shadow-sm border-0">
                     <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center flex-wrap gap-2">
                         <h5 class="mb-0">لیست تمام درخواست‌ها</h5>
-                        <span class="badge bg-light text-primary">{{ number_format($rows->total()) }} مورد</span>
+                        <div class="d-flex align-items-center gap-2 flex-wrap">
+                            <span class="badge bg-light text-primary">{{ number_format($rows->total()) }} مورد</span>
+                            <form method="GET" action="{{ route('simpleWorkflowReport.all-requests.export') }}">
+                                @foreach(($filters ?? []) as $key => $value)
+                                    @continue($value === null || $value === '')
+                                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                @endforeach
+                                <button type="submit" class="btn btn-sm btn-light text-primary fw-semibold">
+                                    خروجی اکسل
+                                </button>
+                            </form>
+                        </div>
                     </div>
                     <div class="card-body">
                         @php


### PR DESCRIPTION
## Summary
- add an Excel export endpoint and download button to the all requests report
- aggregate parallel inbox statuses so the last status column lists concurrent steps
- expose the shared export logic through a dedicated export class and reuse existing filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0f47d32c4833292cb819801496150