### PR TITLE
Add detailed view for workflow report requests

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -94,7 +94,11 @@ class AllRequestsReportController extends Controller
                 DB::raw("MAX(CASE WHEN `key` IN ('first_call_result', 'first-call-result') THEN value END) as first_call_result"),
                 DB::raw("MAX(CASE WHEN `key` IN ('loan_interest', 'loan-interest') THEN value END) as loan_interest"),
                 DB::raw("MAX(CASE WHEN `key` IN ('initial_amount', 'initial-amount') THEN value END) as initial_amount"),
-                DB::raw("MAX(CASE WHEN `key` IN ('feasibility_study', 'feasibility-study') THEN value END) as feasibility_study")
+                DB::raw("MAX(CASE WHEN `key` IN ('feasibility_study', 'feasibility-study') THEN value END) as feasibility_study"),
+                DB::raw("MAX(CASE WHEN `key` IN ('mobile', 'user-mobile', 'user_mobile') THEN value END) as mobile"),
+                DB::raw("MAX(CASE WHEN `key` IN ('user-national_id', 'user_national_id', 'national_id') THEN value END) as user_national_id"),
+                DB::raw("MAX(CASE WHEN `key` IN ('powerhouse_place_info-postal_code', 'powerhouse_place_info_postal_code') THEN value END) as powerhouse_place_info_postal_code"),
+                DB::raw("MAX(CASE WHEN `key` IN ('powerhouse_place_info-address', 'powerhouse_place_info_address') THEN value END) as powerhouse_place_info_address")
             )
             ->groupBy('case_id');
 
@@ -151,6 +155,10 @@ class AllRequestsReportController extends Controller
                 'vars.loan_interest',
                 'vars.initial_amount',
                 'vars.feasibility_study',
+                'vars.mobile',
+                'vars.user_national_id',
+                DB::raw('COALESCE(vars.powerhouse_place_info_postal_code, place.postal_code) as powerhouse_postal_code'),
+                DB::raw('COALESCE(vars.powerhouse_place_info_address, place.address) as powerhouse_address'),
                 'cases.status as case_status',
                 'last_status.inbox_status',
                 'last_status.task_name',
@@ -159,6 +167,23 @@ class AllRequestsReportController extends Controller
                 DB::raw('COALESCE(last_status.task_styled_name, last_status.task_name, last_status.inbox_status, cases.status) as last_status')
             ])
             ->orderByDesc('cases.created_at');
+    }
+
+    public function show(string $caseNumber): View
+    {
+        $row = $this->baseQuery([])
+            ->where('cases.number', $caseNumber)
+            ->first();
+
+        if (!$row) {
+            abort(404);
+        }
+
+        $row = $this->prepareRows(collect([$row]))->first();
+
+        return view('SimpleWorkflowReportView::Core.AllRequests.show', [
+            'requestRow' => $row,
+        ]);
     }
 
     protected function prepareRows(Collection $rows): Collection

--- a/packages/behin-simple-workflow-report/src/Routes/web.php
+++ b/packages/behin-simple-workflow-report/src/Routes/web.php
@@ -31,6 +31,7 @@ Route::name('simpleWorkflowReport.')->prefix('workflow-report')->middleware(['we
     Route::resource('my-request', MyRequestController::class);
 
     Route::get('all-requests/export', [AllRequestsReportController::class, 'export'])->middleware(Access::class. ':گزارش کل درخواست های ثبت شده')->name('all-requests.export');
+    Route::get('all-requests/{case_number}', [AllRequestsReportController::class, 'show'])->middleware(Access::class. ':گزارش کل درخواست های ثبت شده')->name('all-requests.show');
     Route::get('all-requests', [AllRequestsReportController::class, 'index'])->middleware(Access::class. ':گزارش کل درخواست های ثبت شده')->name('all-requests.index');
 
     Route::get('stage-report/export', [StageReportController::class, 'export'])->name('stage-report.export');

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/index.blade.php
@@ -119,6 +119,7 @@
                                     <th>مبلغ اولیه</th>
                                     <th>امکان‌سنجی</th>
                                     <th>آخرین وضعیت درخواست</th>
+                                    <th class="text-center">جزئیات</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -136,10 +137,15 @@
                                         <td>{{ $row->initial_amount ?? '---' }}</td>
                                         <td>{{ $row->feasibility_study ?? '---' }}</td>
                                         <td>{{ $row->last_status ?? '---' }}</td>
+                                        <td class="text-center">
+                                            <a href="{{ route('simpleWorkflowReport.all-requests.show', $row->case_number) }}" class="btn btn-sm btn-outline-primary px-3">
+                                                مشاهده جزئیات
+                                            </a>
+                                        </td>
                                     </tr>
                                 @empty
                                     <tr>
-                                        <td colspan="12" class="text-center text-muted">رکوردی یافت نشد.</td>
+                                        <td colspan="13" class="text-center text-muted">رکوردی یافت نشد.</td>
                                     </tr>
                                 @endforelse
                                 </tbody>

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
@@ -1,0 +1,61 @@
+@extends('behin-layouts.app')
+
+@section('title', 'جزئیات درخواست')
+
+@section('content')
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                    <h4 class="mb-0 fw-bold text-primary">جزئیات درخواست شماره پرونده {{ $requestRow->case_number ?? '---' }}</h4>
+                    <a href="{{ route('simpleWorkflowReport.all-requests.index') }}" class="btn btn-light border-primary text-primary">
+                        بازگشت به فهرست
+                    </a>
+                </div>
+
+                <div class="card border-0 shadow-lg rounded-4 overflow-hidden">
+                    <div class="bg-gradient" style="background: linear-gradient(135deg, #1976d2, #42a5f5);">
+                        <div class="p-4 text-white">
+                            <h5 class="mb-1">{{ trim(($requestRow->user_firstname ?? '') . ' ' . ($requestRow->user_lastname ?? '')) ?: 'کاربر ناشناخته' }}</h5>
+                            <p class="mb-0 opacity-75">آخرین وضعیت: {{ $requestRow->last_status ?? '---' }}</p>
+                        </div>
+                    </div>
+                    <div class="card-body bg-light">
+                        <div class="row g-4">
+                            @php
+                                $details = [
+                                    ['label' => 'شماره پرونده', 'value' => $requestRow->case_number, 'ltr' => true],
+                                    ['label' => 'نام', 'value' => $requestRow->user_firstname],
+                                    ['label' => 'نام خانوادگی', 'value' => $requestRow->user_lastname],
+                                    ['label' => 'شماره همراه', 'value' => $requestRow->mobile, 'ltr' => true],
+                                    ['label' => 'کد ملی', 'value' => $requestRow->user_national_id, 'ltr' => true],
+                                    ['label' => 'شناسه قبض برق', 'value' => $requestRow->electricity_bill_id, 'ltr' => true],
+                                    ['label' => 'نوع نیروگاه', 'value' => $requestRow->powerhouse_type],
+                                    ['label' => 'استان محل نیروگاه', 'value' => $requestRow->powerhouse_province],
+                                    ['label' => 'کد پستی محل نیروگاه', 'value' => $requestRow->powerhouse_postal_code, 'ltr' => true],
+                                    ['label' => 'آدرس محل نیروگاه', 'value' => $requestRow->powerhouse_address],
+                                    ['label' => 'ظرفیت درخواستی', 'value' => $requestRow->requested_capacity_of_powerhouse],
+                                    ['label' => 'نتیجه اولین تماس', 'value' => $requestRow->first_call_result],
+                                    ['label' => 'سود تسهیلات', 'value' => $requestRow->loan_interest],
+                                    ['label' => 'مبلغ اولیه', 'value' => $requestRow->initial_amount],
+                                    ['label' => 'امکان‌سنجی', 'value' => $requestRow->feasibility_study],
+                                ];
+                            @endphp
+
+                            @foreach($details as $detail)
+                                <div class="col-md-6">
+                                    <div class="bg-white rounded-4 shadow-sm h-100 p-3 d-flex flex-column gap-2 border border-light">
+                                        <span class="text-secondary small fw-semibold">{{ $detail['label'] }}</span>
+                                        <span class="fw-bold text-dark" @if(($detail['ltr'] ?? false)) dir="ltr" @endif>
+                                            {{ $detail['value'] ?? '---' }}
+                                        </span>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection


### PR DESCRIPTION
## Summary
- expose a dedicated route and controller action to show full details for each workflow request
- surface the detail link alongside each entry in the all-requests table
- build a material-inspired detail page that highlights the existing columns plus mobile, national ID, postal code, and address fields

## Testing
- php -l packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php

------
https://chatgpt.com/codex/tasks/task_e_68e111e64c10833289131005a6943509