### PR TITLE
Fix all requests report duplicates and export filters

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -32,10 +32,13 @@ class AllRequestsReportController extends Controller
 
     public function export(Request $request): BinaryFileResponse
     {
-        $filters = $request->except('page');
+        $filters = Arr::except($request->except('page'), ['per_page']);
 
         $rows = $this->prepareRows(
-            $this->baseQuery($filters)->get()
+            $this->applyFilters(
+                $this->baseQuery($filters),
+                $filters
+            )->get()
         );
 
         return Excel::download(
@@ -99,7 +102,7 @@ class AllRequestsReportController extends Controller
             ->groupBy('case_id');
 
         $latestInbox = DB::table('wf_inbox')
-            ->select('case_id', DB::raw('MAX(created_at) as latest_created_at'))
+            ->select('case_id', DB::raw('MAX(id) as latest_id'))
             ->groupBy('case_id');
 
         $taskStyledNameColumn = Schema::hasColumn('wf_task', 'styled_name')
@@ -109,7 +112,7 @@ class AllRequestsReportController extends Controller
         $lastStatuses = DB::table('wf_inbox as inbox')
             ->joinSub($latestInbox, 'latest', function ($join) {
                 $join->on('inbox.case_id', '=', 'latest.case_id')
-                    ->on('inbox.created_at', '=', 'latest.latest_created_at');
+                    ->on('inbox.id', '=', 'latest.latest_id');
             })
             ->leftJoin('wf_task as tasks', 'tasks.id', '=', 'inbox.task_id')
             ->select(


### PR DESCRIPTION
## Summary
- ensure the latest inbox row joins by id to avoid duplicate request rows
- apply the active filters when exporting the all requests report to Excel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11439f1a08332985260ed3786d5e1