### PR TITLE
Add conversation history view model to all requests detail

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Schema;
 use Maatwebsite\Excel\Facades\Excel;
 use Behin\SimpleWorkflowReport\Exports\AllRequestsReportExport;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Behin\SimpleWorkflow\Models\Core\ViewModel;
 
 class AllRequestsReportController extends Controller
 {
@@ -147,6 +148,7 @@ class AllRequestsReportController extends Controller
                 $join->on('cases.id', '=', 'active_statuses.case_id');
             })
             ->select([
+                'cases.id as case_id',
                 'cases.number as case_number',
                 'vars.user_firstname',
                 'vars.user_lastname',
@@ -186,6 +188,7 @@ class AllRequestsReportController extends Controller
 
         return view('SimpleWorkflowReportView::Core.AllRequests.show', [
             'requestRow' => $row,
+            'conversationViewModel' => ViewModel::find('912880ce-7acf-4735-9170-cbc34b39362b'),
         ]);
     }
 

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
@@ -21,6 +21,7 @@
                         </div>
                     </div>
                     <div class="card-body bg-light">
+                        <input type="hidden" id="caseId" value="{{ $requestRow->case_id ?? '' }}">
                         <div class="row g-4">
                             @php
                                 $details = [
@@ -53,6 +54,46 @@
                                 </div>
                             @endforeach
                         </div>
+                        @if($conversationViewModel)
+                            @php
+                                $conversationColumns = collect(explode(',', $conversationViewModel->default_fields ?? ''))
+                                    ->map(fn ($column) => trim($column))
+                                    ->filter()
+                                    ->values();
+                            @endphp
+                            <div class="card border-0 shadow-sm rounded-4 mt-4">
+                                <div class="card-header bg-white d-flex justify-content-between align-items-center flex-wrap gap-2">
+                                    <h5 class="mb-0 fw-bold text-primary">تاریخچه مکالمات</h5>
+                                    <button type="button" class="btn btn-outline-primary d-flex align-items-center gap-1"
+                                            onclick="get_view_model_rows('{{ $conversationViewModel->id }}', '{{ $conversationViewModel->api_key }}')">
+                                        <span class="material-icons">refresh</span>
+                                        بروزرسانی
+                                    </button>
+                                </div>
+                                <div class="card-body">
+                                    <div class="table-responsive">
+                                        <table class="table table-striped align-middle" id="{{ $conversationViewModel->id }}">
+                                            @if($conversationViewModel->show_as === 'table' && $conversationColumns->isNotEmpty())
+                                                <thead class="table-light">
+                                                    <tr>
+                                                        @foreach($conversationColumns as $column)
+                                                            <th>{{ trans('fields.' . $column) }}</th>
+                                                        @endforeach
+                                                        <th class="text-center">{{ trans('fields.Action') }}</th>
+                                                    </tr>
+                                                </thead>
+                                            @endif
+                                            <tbody></tbody>
+                                        </table>
+                                    </div>
+                                </div>
+                            </div>
+                            <script>
+                                document.addEventListener('DOMContentLoaded', function () {
+                                    get_view_model_rows('{{ $conversationViewModel->id }}', '{{ $conversationViewModel->api_key }}');
+                                });
+                            </script>
+                        @endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- expose the case id and load the conversation history view model for request detail pages
- render the conversation history table with refresh support on the all requests detail view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e116b1d89c833296137b837d647c5d