### PR TITLE
Integrate AMI call history into all requests detail view

### DIFF
--- a/packages/behin-ami/src/AmiServiceProvider.php
+++ b/packages/behin-ami/src/AmiServiceProvider.php
@@ -2,13 +2,18 @@
 
 namespace Behin\Ami;
 
+use Behin\Ami\Services\CallHistoryService;
 use Illuminate\Support\ServiceProvider;
 
 class AmiServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        $this->mergeConfigFrom(__DIR__ . '/config/behin-ami.php', 'behin-ami');
+
+        $this->app->singleton(CallHistoryService::class, function () {
+            return new CallHistoryService();
+        });
     }
 
     public function boot(): void
@@ -16,5 +21,11 @@ class AmiServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom(__DIR__.'/migrations');
         $this->loadRoutesFrom(__DIR__.'/routes/web.php');
         $this->loadViewsFrom(__DIR__.'/views', 'ami');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/config/behin-ami.php' => config_path('behin-ami.php'),
+            ], 'behin-ami-config');
+        }
     }
 }

--- a/packages/behin-ami/src/Controllers/CallRecordingController.php
+++ b/packages/behin-ami/src/Controllers/CallRecordingController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Behin\Ami\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class CallRecordingController
+{
+    public function download(Request $request)
+    {
+        $token = $request->query('token');
+        if (!$token) {
+            abort(404);
+        }
+
+        $decoded = json_decode(base64_decode($token, true) ?: '', true);
+        if (!is_array($decoded)) {
+            abort(404);
+        }
+
+        $disk = $decoded['disk'] ?? null;
+        $path = $decoded['path'] ?? null;
+
+        if (!$path) {
+            abort(404);
+        }
+
+        $fileName = $request->query('name') ?: basename($path);
+
+        if ($disk) {
+            $allowedDisk = config('behin-ami.recordings.disk');
+            if (!$allowedDisk || $disk !== $allowedDisk) {
+                abort(404);
+            }
+
+            if (!Storage::disk($disk)->exists($path)) {
+                abort(404);
+            }
+
+            return Storage::disk($disk)->download($path, $fileName);
+        }
+
+        $basePath = config('behin-ami.recordings.base_path');
+        if (!$basePath) {
+            abort(404);
+        }
+
+        $baseReal = realpath($basePath);
+        $fileReal = realpath($path);
+
+        if (!$baseReal || !$fileReal || !str_starts_with($fileReal, $baseReal) || !is_file($fileReal)) {
+            abort(404);
+        }
+
+        return response()->download($fileReal, $fileName);
+    }
+}

--- a/packages/behin-ami/src/Services/CallHistoryService.php
+++ b/packages/behin-ami/src/Services/CallHistoryService.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Behin\Ami\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+class CallHistoryService
+{
+    protected ?string $lastError = null;
+
+    /** @var array<int, string> */
+    protected array $lastSearchNumbers = [];
+
+    /**
+     * دریافت تاریخچه مکالمات برای شماره مشخص شده.
+     */
+    public function getCallsByPhone(?string $phone, ?int $limit = null): Collection
+    {
+        $this->lastError = null;
+        $this->lastSearchNumbers = [];
+
+        $phone = $this->sanitizePhone($phone);
+        if ($phone === null) {
+            return collect();
+        }
+
+        $numbers = $this->resolvePossibleNumbers($phone);
+        if (empty($numbers)) {
+            return collect();
+        }
+
+        $this->lastSearchNumbers = $numbers;
+
+        $connection = config('behin-ami.cdr_connection') ?: config('database.default');
+        $table = config('behin-ami.cdr_table', 'cdr');
+
+        if (!$table) {
+            $this->setError('جدول مکالمات برای دریافت اطلاعات تعریف نشده است.');
+            return collect();
+        }
+
+        try {
+            if (!Schema::connection($connection)->hasTable($table)) {
+                $this->setError('جدول مکالمات در پایگاه داده پیدا نشد.');
+                return collect();
+            }
+        } catch (\Throwable $exception) {
+            $this->setError('امکان دسترسی به جدول مکالمات وجود ندارد.', $exception);
+            return collect();
+        }
+
+        $columnsConfig = (array) config('behin-ami.columns', []);
+
+        $dateColumn = $this->resolveColumn($connection, $table, $columnsConfig['date'] ?? 'calldate');
+        if (!$dateColumn) {
+            $this->setError('ستون تاریخ مکالمه در جدول وجود ندارد.');
+            return collect();
+        }
+
+        $sourceColumn = $this->resolveColumn($connection, $table, $columnsConfig['source'] ?? 'src');
+        $destinationColumn = $this->resolveColumn($connection, $table, $columnsConfig['destination'] ?? 'dst');
+
+        if (!$sourceColumn && !$destinationColumn) {
+            $this->setError('ستون‌های مرتبط با شماره تماس در جدول مکالمات یافت نشد.');
+            return collect();
+        }
+
+        $durationColumn = $this->resolveColumn($connection, $table, $columnsConfig['duration'] ?? 'billsec');
+        $fallbackDurationColumn = $this->resolveColumn($connection, $table, $columnsConfig['duration_fallback'] ?? 'duration');
+        $statusColumn = $this->resolveColumn($connection, $table, $columnsConfig['status'] ?? 'disposition');
+        $recordingColumn = $this->resolveColumn($connection, $table, $columnsConfig['recording'] ?? 'recordingfile');
+
+        $selectColumns = [
+            $dateColumn . ' as started_at_raw',
+        ];
+
+        if ($sourceColumn) {
+            $selectColumns[] = $sourceColumn . ' as source';
+        }
+
+        if ($destinationColumn) {
+            $selectColumns[] = $destinationColumn . ' as destination';
+        }
+
+        if ($durationColumn) {
+            $selectColumns[] = $durationColumn . ' as primary_duration';
+        }
+
+        if ($fallbackDurationColumn && $fallbackDurationColumn !== $durationColumn) {
+            $selectColumns[] = $fallbackDurationColumn . ' as fallback_duration';
+        }
+
+        if ($statusColumn) {
+            $selectColumns[] = $statusColumn . ' as status';
+        }
+
+        if ($recordingColumn) {
+            $selectColumns[] = $recordingColumn . ' as recording';
+        }
+
+        $limit = $limit ?? (int) config('behin-ami.default_limit', 50);
+
+        try {
+            $query = DB::connection($connection)
+                ->table($table)
+                ->select($selectColumns)
+                ->orderByDesc($dateColumn)
+                ->where(function ($query) use ($numbers, $sourceColumn, $destinationColumn) {
+                    foreach ($numbers as $number) {
+                        if ($sourceColumn) {
+                            $query->orWhere($sourceColumn, $number);
+                        }
+                        if ($destinationColumn) {
+                            $query->orWhere($destinationColumn, $number);
+                        }
+                    }
+                });
+
+            if ($limit > 0) {
+                $query->limit($limit);
+            }
+
+            $rows = $query->get();
+        } catch (\Throwable $exception) {
+            $this->setError('خطا در دریافت اطلاعات مکالمات از پایگاه داده.', $exception);
+            return collect();
+        }
+
+        $normalizedNumbers = array_map([$this, 'normalizeForComparison'], $numbers);
+
+        return $rows->map(function ($row) use ($normalizedNumbers) {
+            $startedAt = null;
+            if (!empty($row->started_at_raw)) {
+                try {
+                    $startedAt = Carbon::parse($row->started_at_raw)->setTimezone(config('app.timezone'));
+                } catch (\Throwable $exception) {
+                    Log::debug('AMI call history: unable to parse call date', [
+                        'value' => $row->started_at_raw,
+                        'exception' => $exception->getMessage(),
+                    ]);
+                }
+            }
+
+            $source = $row->source ?? null;
+            $destination = $row->destination ?? null;
+
+            $direction = 'unknown';
+            $sourceNormalized = $this->normalizeForComparison($source);
+            if ($source && in_array($sourceNormalized, $normalizedNumbers, true)) {
+                $direction = 'outbound';
+            }
+
+            $destinationNormalized = $this->normalizeForComparison($destination);
+            if ($direction === 'unknown' && $destination && in_array($destinationNormalized, $normalizedNumbers, true)) {
+                $direction = 'inbound';
+            }
+
+            $counterparty = $direction === 'outbound'
+                ? ($destination ?: $source)
+                : ($direction === 'inbound' ? ($source ?: $destination) : ($destination ?: $source));
+
+            $durationSeconds = (int) ($row->primary_duration ?? $row->fallback_duration ?? 0);
+            if ($durationSeconds < 0) {
+                $durationSeconds = 0;
+            }
+
+            $recording = $this->resolveRecording($row->recording ?? null);
+
+            return [
+                'started_at' => $startedAt,
+                'source' => $source,
+                'destination' => $destination,
+                'direction' => $direction,
+                'counterparty' => $counterparty,
+                'duration_seconds' => $durationSeconds,
+                'duration_human' => $this->formatDuration($durationSeconds),
+                'status' => $row->status ?? null,
+                'recording' => $recording,
+            ];
+        });
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getLastSearchNumbers(): array
+    {
+        return $this->lastSearchNumbers;
+    }
+
+    protected function setError(string $message, ?\Throwable $exception = null): void
+    {
+        $this->lastError = $message;
+
+        if ($exception) {
+            Log::warning('AMI call history error: ' . $message, [
+                'exception' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    protected function sanitizePhone(?string $phone): ?string
+    {
+        if ($phone === null) {
+            return null;
+        }
+
+        $trimmed = trim($phone);
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function resolvePossibleNumbers(string $phone): array
+    {
+        $digits = preg_replace('/\D+/', '', $phone) ?? '';
+        $last10 = substr($digits, -10) ?: $digits;
+
+        $candidates = array_filter([
+            $phone,
+            $digits,
+            $last10,
+            $last10 ? '0' . $last10 : null,
+            $last10 ? '98' . $last10 : null,
+            $last10 ? '+98' . $last10 : null,
+        ]);
+
+        return array_values(array_unique(array_map('strval', $candidates)));
+    }
+
+    protected function normalizeForComparison(?string $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        $digits = preg_replace('/\D+/', '', $value) ?? '';
+        return substr($digits, -10) ?: $digits;
+    }
+
+    protected function formatDuration(int $seconds): string
+    {
+        $minutes = intdiv($seconds, 60);
+        $remaining = $seconds % 60;
+
+        return sprintf('%02d:%02d', $minutes, $remaining);
+    }
+
+    protected function resolveRecording(?string $recording): ?array
+    {
+        if ($recording === null) {
+            return null;
+        }
+
+        $recording = trim($recording);
+        if ($recording === '') {
+            return null;
+        }
+
+        $fileName = basename($recording);
+        $result = [
+            'name' => $fileName,
+            'available' => false,
+            'download_url' => null,
+            'stream_url' => null,
+            'token' => null,
+        ];
+
+        if (filter_var($recording, FILTER_VALIDATE_URL)) {
+            $result['available'] = true;
+            $result['download_url'] = $recording;
+            $result['stream_url'] = $recording;
+            return $result;
+        }
+
+        $recordingConfig = (array) config('behin-ami.recordings', []);
+
+        $baseUrl = $recordingConfig['base_url'] ?? null;
+        if ($baseUrl) {
+            $url = rtrim($baseUrl, '/') . '/' . ltrim($recording, '/');
+            $result['available'] = true;
+            $result['download_url'] = $url;
+            $result['stream_url'] = $url;
+        }
+
+        $disk = $recordingConfig['disk'] ?? null;
+        $prefix = trim($recordingConfig['prefix'] ?? '', '/');
+        $storagePath = ltrim($recording, '/');
+        if ($prefix !== '') {
+            $storagePath = trim($prefix . '/' . $storagePath, '/');
+        }
+
+        if ($disk) {
+            try {
+                if (Storage::disk($disk)->exists($storagePath)) {
+                    $token = $this->encodeDownloadToken([
+                        'disk' => $disk,
+                        'path' => $storagePath,
+                    ]);
+
+                    $result['available'] = true;
+                    $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
+                    $result['stream_url'] = Storage::disk($disk)->url($storagePath);
+                    $result['token'] = $token;
+
+                    return $result;
+                }
+            } catch (\Throwable $exception) {
+                Log::debug('AMI call history: unable to access storage disk', [
+                    'disk' => $disk,
+                    'exception' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        $basePath = $recordingConfig['base_path'] ?? null;
+        if ($basePath) {
+            $fullPath = $this->resolveAbsolutePath($basePath, $recording);
+            if ($fullPath && is_file($fullPath)) {
+                $token = $this->encodeDownloadToken([
+                    'path' => $fullPath,
+                ]);
+
+                $result['available'] = true;
+                $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
+                $result['token'] = $token;
+            }
+        }
+
+        return $result;
+    }
+
+    protected function encodeDownloadToken(array $payload): string
+    {
+        return base64_encode(json_encode($payload));
+    }
+
+    protected function resolveAbsolutePath(string $basePath, string $relative): ?string
+    {
+        $baseReal = realpath($basePath);
+        if (!$baseReal) {
+            return null;
+        }
+
+        $fullPath = $baseReal . DIRECTORY_SEPARATOR . ltrim($relative, DIRECTORY_SEPARATOR);
+        $fullReal = realpath($fullPath);
+
+        if (!$fullReal) {
+            return null;
+        }
+
+        if (!str_starts_with($fullReal, $baseReal)) {
+            return null;
+        }
+
+        return $fullReal;
+    }
+
+    protected function resolveColumn(string $connection, string $table, ?string $column): ?string
+    {
+        if (!$column) {
+            return null;
+        }
+
+        try {
+            return Schema::connection($connection)->hasColumn($table, $column) ? $column : null;
+        } catch (\Throwable $exception) {
+            Log::debug('AMI call history: unable to verify column', [
+                'table' => $table,
+                'column' => $column,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/packages/behin-ami/src/config/behin-ami.php
+++ b/packages/behin-ami/src/config/behin-ami.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'cdr_connection' => env('AMI_CDR_CONNECTION'),
+    'cdr_table' => env('AMI_CDR_TABLE', 'cdr'),
+    'columns' => [
+        'date' => env('AMI_CDR_DATE_COLUMN', 'calldate'),
+        'source' => env('AMI_CDR_SOURCE_COLUMN', 'src'),
+        'destination' => env('AMI_CDR_DESTINATION_COLUMN', 'dst'),
+        'duration' => env('AMI_CDR_DURATION_COLUMN', 'billsec'),
+        'duration_fallback' => env('AMI_CDR_DURATION_FALLBACK_COLUMN', 'duration'),
+        'status' => env('AMI_CDR_STATUS_COLUMN', 'disposition'),
+        'recording' => env('AMI_CDR_RECORDING_COLUMN', 'recordingfile'),
+    ],
+    'default_limit' => env('AMI_CDR_LIMIT', 50),
+    'recordings' => [
+        'disk' => env('AMI_RECORDINGS_DISK'),
+        'prefix' => env('AMI_RECORDINGS_PREFIX', ''),
+        'base_path' => env('AMI_RECORDINGS_BASE_PATH'),
+        'base_url' => env('AMI_RECORDINGS_BASE_URL'),
+    ],
+];

--- a/packages/behin-ami/src/routes/web.php
+++ b/packages/behin-ami/src/routes/web.php
@@ -3,9 +3,11 @@
 use Illuminate\Support\Facades\Route;
 use Behin\Ami\Controllers\AmiSettingController;
 use Behin\Ami\Controllers\AmiStatusController;
+use Behin\Ami\Controllers\CallRecordingController;
 
 Route::prefix('ami')->middleware(['web', 'auth'])->name('ami.')->group(function () {
     Route::get('settings', [AmiSettingController::class, 'index'])->name('settings');
     Route::post('settings', [AmiSettingController::class, 'store'])->name('settings.store');
     Route::get('status', [AmiStatusController::class, 'index'])->name('status');
+    Route::get('calls/recordings/download', [CallRecordingController::class, 'download'])->name('calls.recordings.download');
 });

--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -3,6 +3,8 @@
 namespace Behin\SimpleWorkflowReport\Controllers\Core;
 
 use App\Http\Controllers\Controller;
+use Behin\Ami\Services\CallHistoryService;
+use Behin\SimpleWorkflowReport\Exports\AllRequestsReportExport;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
@@ -11,9 +13,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Maatwebsite\Excel\Facades\Excel;
-use Behin\SimpleWorkflowReport\Exports\AllRequestsReportExport;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Behin\SimpleWorkflow\Models\Core\ViewModel;
 
 class AllRequestsReportController extends Controller
 {
@@ -186,9 +186,24 @@ class AllRequestsReportController extends Controller
 
         $row = $this->prepareRows(collect([$row]))->first();
 
+        /** @var CallHistoryService $callHistoryService */
+        $callHistoryService = app(CallHistoryService::class);
+
+        $callRecords = collect();
+        $callRecordsError = null;
+        $searchedNumbers = [];
+
+        if (!empty($row->mobile)) {
+            $callRecords = $callHistoryService->getCallsByPhone($row->mobile);
+            $callRecordsError = $callHistoryService->getLastError();
+            $searchedNumbers = $callHistoryService->getLastSearchNumbers();
+        }
+
         return view('SimpleWorkflowReportView::Core.AllRequests.show', [
             'requestRow' => $row,
-            'conversationViewModel' => ViewModel::find('912880ce-7acf-4735-9170-cbc34b39362b'),
+            'callRecords' => $callRecords,
+            'callRecordsError' => $callRecordsError,
+            'callRecordsSearchedNumbers' => $searchedNumbers,
         ]);
     }
 

--- a/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
+++ b/packages/behin-simple-workflow-report/src/Views/Core/AllRequests/show.blade.php
@@ -54,46 +54,99 @@
                                 </div>
                             @endforeach
                         </div>
-                        @if($conversationViewModel)
-                            @php
-                                $conversationColumns = collect(explode(',', $conversationViewModel->default_fields ?? ''))
-                                    ->map(fn ($column) => trim($column))
-                                    ->filter()
-                                    ->values();
-                            @endphp
-                            <div class="card border-0 shadow-sm rounded-4 mt-4">
-                                <div class="card-header bg-white d-flex justify-content-between align-items-center flex-wrap gap-2">
-                                    <h5 class="mb-0 fw-bold text-primary">تاریخچه مکالمات</h5>
-                                    <button type="button" class="btn btn-outline-primary d-flex align-items-center gap-1"
-                                            onclick="get_view_model_rows('{{ $conversationViewModel->id }}', '{{ $conversationViewModel->api_key }}')">
-                                        <span class="material-icons">refresh</span>
-                                        بروزرسانی
-                                    </button>
-                                </div>
-                                <div class="card-body">
-                                    <div class="table-responsive">
-                                        <table class="table table-striped align-middle" id="{{ $conversationViewModel->id }}">
-                                            @if($conversationViewModel->show_as === 'table' && $conversationColumns->isNotEmpty())
-                                                <thead class="table-light">
-                                                    <tr>
-                                                        @foreach($conversationColumns as $column)
-                                                            <th>{{ trans('fields.' . $column) }}</th>
-                                                        @endforeach
-                                                        <th class="text-center">{{ trans('fields.Action') }}</th>
-                                                    </tr>
-                                                </thead>
-                                            @endif
-                                            <tbody></tbody>
-                                        </table>
-                                    </div>
+                        @php
+                            $callRecords = $callRecords ?? collect();
+                            $callRecordsError = $callRecordsError ?? null;
+                            $callRecordsSearchedNumbers = $callRecordsSearchedNumbers ?? [];
+                            $directionLabels = [
+                                'inbound' => 'ورودی',
+                                'outbound' => 'خروجی',
+                                'unknown' => 'نامشخص',
+                            ];
+                        @endphp
+
+                        <div class="card border-0 shadow-sm rounded-4 mt-4">
+                            <div class="card-header bg-white d-flex justify-content-between align-items-center flex-wrap gap-2">
+                                <div>
+                                    <h5 class="mb-0 fw-bold text-primary">تاریخچه مکالمات تلفنی (AMI)</h5>
+                                    @if(!empty($callRecordsSearchedNumbers))
+                                        <span class="text-muted small">جستجو بر اساس: {{ implode('، ', $callRecordsSearchedNumbers) }}</span>
+                                    @elseif(!empty($requestRow->mobile))
+                                        <span class="text-muted small">شماره جستجو: {{ $requestRow->mobile }}</span>
+                                    @else
+                                        <span class="text-muted small">شماره تماسی برای این درخواست ثبت نشده است.</span>
+                                    @endif
                                 </div>
                             </div>
-                            <script>
-                                document.addEventListener('DOMContentLoaded', function () {
-                                    get_view_model_rows('{{ $conversationViewModel->id }}', '{{ $conversationViewModel->api_key }}');
-                                });
-                            </script>
-                        @endif
+                            <div class="card-body">
+                                @if($callRecordsError)
+                                    <div class="alert alert-warning" role="alert">
+                                        {{ $callRecordsError }}
+                                    </div>
+                                @endif
+
+                                @if($callRecords->isEmpty())
+                                    <p class="text-muted mb-0 text-center">مکالمه‌ای برای نمایش یافت نشد.</p>
+                                @else
+                                    <div class="table-responsive">
+                                        <table class="table table-striped align-middle mb-0">
+                                            <thead class="table-light">
+                                                <tr>
+                                                    <th>تاریخ و زمان</th>
+                                                    <th>نوع مکالمه</th>
+                                                    <th>مدت</th>
+                                                    <th>وضعیت</th>
+                                                    <th class="text-center">فایل مکالمه</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                @foreach($callRecords as $record)
+                                                    <tr>
+                                                        <td>
+                                                            @if(!empty($record['started_at']))
+                                                                {{ $record['started_at']->format('Y/m/d H:i') }}
+                                                            @else
+                                                                ---
+                                                            @endif
+                                                        </td>
+                                                        <td>
+                                                            <span class="badge bg-primary-subtle text-primary fw-semibold">{{ $directionLabels[$record['direction']] ?? $record['direction'] }}</span>
+                                                            <div class="small text-muted mt-1">{{ $record['counterparty'] ?? '---' }}</div>
+                                                        </td>
+                                                        <td>
+                                                            <span class="fw-bold">{{ $record['duration_human'] ?? '00:00' }}</span>
+                                                            @if(!empty($record['duration_seconds']))
+                                                                <div class="small text-muted">{{ $record['duration_seconds'] }} ثانیه</div>
+                                                            @endif
+                                                        </td>
+                                                        <td>
+                                                            <span class="badge bg-light text-dark border">{{ $record['status'] ?? '---' }}</span>
+                                                        </td>
+                                                        <td class="text-center">
+                                                            @if(!empty($record['recording']['available']) && !empty($record['recording']['download_url']))
+                                                                <div class="d-flex flex-column gap-2 align-items-center">
+                                                                    <a class="btn btn-sm btn-outline-primary" href="{{ $record['recording']['download_url'] }}">
+                                                                        دانلود فایل
+                                                                    </a>
+                                                                    @if(!empty($record['recording']['stream_url']))
+                                                                        <audio controls preload="none" class="w-100">
+                                                                            <source src="{{ $record['recording']['stream_url'] }}">
+                                                                            مرورگر شما از پخش صوت پشتیبانی نمی‌کند.
+                                                                        </audio>
+                                                                    @endif
+                                                                </div>
+                                                            @else
+                                                                <span class="text-muted">فاقد فایل</span>
+                                                            @endif
+                                                        </td>
+                                                    </tr>
+                                                @endforeach
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a reusable CallHistoryService in behin-ami to read CDR data and resolve recording links
- expose a secured recording download endpoint and configuration publishing for AMI
- show AMI phone call history with download/playback options in the workflow report request detail page

## Testing
- `php artisan test` *(fails: Carbon\CarbonPeriod constant type mismatch on current dependency stack)*

------
https://chatgpt.com/codex/tasks/task_e_68e12721eec08332b0efba306b8ce8a1