### PR TITLE
Fix recording download link generation

### DIFF
--- a/packages/behin-ami/src/Services/CallHistoryService.php
+++ b/packages/behin-ami/src/Services/CallHistoryService.php
@@ -286,14 +286,6 @@ class CallHistoryService
 
         $recordingConfig = (array) config('behin-ami.recordings', []);
 
-        $baseUrl = $recordingConfig['base_url'] ?? null;
-        if ($baseUrl) {
-            $url = rtrim($baseUrl, '/') . '/' . ltrim($recording, '/');
-            $result['available'] = true;
-            $result['download_url'] = $url;
-            $result['stream_url'] = $url;
-        }
-
         $disk = $recordingConfig['disk'] ?? null;
         $prefix = trim($recordingConfig['prefix'] ?? '', '/');
         $storagePath = ltrim($recording, '/');
@@ -335,6 +327,16 @@ class CallHistoryService
                 $result['available'] = true;
                 $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
                 $result['token'] = $token;
+            }
+        }
+
+        if (!$result['available']) {
+            $baseUrl = $recordingConfig['base_url'] ?? null;
+            if ($baseUrl) {
+                $url = rtrim($baseUrl, '/') . '/' . ltrim($recording, '/');
+                $result['available'] = true;
+                $result['download_url'] = $url;
+                $result['stream_url'] = $url;
             }
         }
 


### PR DESCRIPTION
## Summary
- adjust the recording URL resolution logic to prefer stored files before falling back to a base URL
- ensure generated download links continue to work when the configured base URL is unreachable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1623994d88332b5cb75ab76af28ce