### PR TITLE
Stream Issabel recordings through authenticated proxy

### DIFF
--- a/packages/behin-ami/src/Controllers/CallRecordingController.php
+++ b/packages/behin-ami/src/Controllers/CallRecordingController.php
@@ -2,8 +2,15 @@
 
 namespace Behin\Ami\Controllers;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
 
 class CallRecordingController
 {
@@ -21,14 +28,23 @@ class CallRecordingController
 
         $disk = $decoded['disk'] ?? null;
         $path = $decoded['path'] ?? null;
+        $remotePath = $decoded['remote_path'] ?? null;
 
-        if (!$path) {
+        if (!$path && !$remotePath) {
             abort(404);
         }
 
-        $fileName = $request->query('name') ?: basename($path);
+        $defaultName = $path ? basename($path) : ($remotePath ? basename($remotePath) : 'recording.wav');
+        $fileName = $request->query('name') ?: $defaultName;
+        if (str_contains($fileName, '?')) {
+            $fileName = strstr($fileName, '?', true) ?: $fileName;
+        }
+        if ($fileName === '') {
+            $fileName = 'recording.wav';
+        }
+        $inline = $request->boolean('inline');
 
-        if ($disk) {
+        if ($disk && $path) {
             $allowedDisk = config('behin-ami.recordings.disk');
             if (!$allowedDisk || $disk !== $allowedDisk) {
                 abort(404);
@@ -38,21 +54,192 @@ class CallRecordingController
                 abort(404);
             }
 
-            return Storage::disk($disk)->download($path, $fileName);
+            return $this->streamLocalDisk($disk, $path, $fileName, $inline);
         }
 
-        $basePath = config('behin-ami.recordings.base_path');
-        if (!$basePath) {
+        if ($path) {
+            $basePath = config('behin-ami.recordings.base_path');
+            if (!$basePath) {
+                abort(404);
+            }
+
+            $baseReal = realpath($basePath);
+            $fileReal = realpath($path);
+
+            if (!$baseReal || !$fileReal || !str_starts_with($fileReal, $baseReal) || !is_file($fileReal)) {
+                abort(404);
+            }
+
+            return $this->streamLocalFile($fileReal, $fileName, $inline);
+        }
+
+        if ($remotePath) {
+            return $this->streamFromIssabel($remotePath, $fileName, $inline);
+        }
+
+        abort(404);
+    }
+
+    protected function streamLocalDisk(string $disk, string $path, string $fileName, bool $inline): Response
+    {
+        if ($inline) {
+            $stream = Storage::disk($disk)->readStream($path);
+            if (!$stream) {
+                abort(404);
+            }
+
+            return $this->streamResponse(function () use ($stream) {
+                while (!feof($stream)) {
+                    echo fread($stream, 8192);
+                }
+                fclose($stream);
+            }, $fileName, $inline, Storage::disk($disk)->mimeType($path) ?: null, $this->resolveStorageSize($disk, $path));
+        }
+
+        return Storage::disk($disk)->download($path, $fileName);
+    }
+
+    protected function streamLocalFile(string $filePath, string $fileName, bool $inline): Response
+    {
+        if (!$inline) {
+            return response()->download($filePath, $fileName);
+        }
+
+        $mimeType = mime_content_type($filePath) ?: null;
+        $fileSize = is_file($filePath) ? filesize($filePath) ?: null : null;
+
+        return $this->streamResponse(function () use ($filePath) {
+            $handle = fopen($filePath, 'rb');
+            if ($handle === false) {
+                abort(404);
+            }
+
+            try {
+                while (!feof($handle)) {
+                    echo fread($handle, 8192);
+                }
+            } finally {
+                fclose($handle);
+            }
+        }, $fileName, true, $mimeType, $fileSize);
+    }
+
+    protected function streamFromIssabel(string $remotePath, string $fileName, bool $inline): StreamedResponse
+    {
+        $config = (array) config('behin-ami.recordings.issabel', []);
+        $baseUrl = rtrim((string) ($config['base_url'] ?? ''), '/');
+        $username = $config['username'] ?? null;
+        $password = $config['password'] ?? null;
+
+        if ($baseUrl === '' || $username === null || $password === null) {
             abort(404);
         }
 
-        $baseReal = realpath($basePath);
-        $fileReal = realpath($path);
+        $loginPath = ltrim((string) ($config['login_path'] ?? '/index.php?module=auth&action=login'), '/');
+        $usernameField = (string) ($config['username_field'] ?? 'input_user');
+        $passwordField = (string) ($config['password_field'] ?? 'input_pass');
+        $extraFields = (array) ($config['extra_fields'] ?? []);
+        $verifySsl = (bool) ($config['verify_ssl'] ?? true);
+        $timeout = (int) ($config['timeout'] ?? 15);
 
-        if (!$baseReal || !$fileReal || !str_starts_with($fileReal, $baseReal) || !is_file($fileReal)) {
+        $client = new Client([
+            'base_uri' => $baseUrl . '/',
+            'timeout' => max($timeout, 1),
+            'cookies' => true,
+            'http_errors' => false,
+            'verify' => $verifySsl,
+        ]);
+
+        try {
+            $loginResponse = $client->post($loginPath, [
+                'form_params' => array_merge($extraFields, [
+                    $usernameField => $username,
+                    $passwordField => $password,
+                ]),
+                'allow_redirects' => true,
+            ]);
+        } catch (GuzzleException $exception) {
+            Log::warning('AMI call history: Issabel login failed', [
+                'exception' => $exception->getMessage(),
+            ]);
             abort(404);
         }
 
-        return response()->download($fileReal, $fileName);
+        if ($loginResponse->getStatusCode() >= 400) {
+            Log::warning('AMI call history: Issabel login returned unexpected status', [
+                'status' => $loginResponse->getStatusCode(),
+            ]);
+            abort(404);
+        }
+
+        try {
+            $response = $client->get(ltrim($remotePath, '/'), [
+                'stream' => true,
+            ]);
+        } catch (GuzzleException $exception) {
+            Log::warning('AMI call history: Issabel recording fetch failed', [
+                'exception' => $exception->getMessage(),
+                'path' => $remotePath,
+            ]);
+            abort(404);
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            Log::warning('AMI call history: Issabel recording fetch returned unexpected status', [
+                'status' => $response->getStatusCode(),
+                'path' => $remotePath,
+            ]);
+            abort(404);
+        }
+
+        $body = $response->getBody();
+        $mimeType = $response->getHeaderLine('Content-Type') ?: null;
+        $contentLength = $response->getHeaderLine('Content-Length') ?: null;
+
+        return $this->streamResponse(function () use ($body) {
+            while (!$body->eof()) {
+                echo $body->read(8192);
+            }
+        }, $fileName, $inline, $mimeType, $contentLength ? (int) $contentLength : null);
+    }
+
+    /**
+     * @param callable():void $callback
+     */
+    protected function streamResponse(callable $callback, string $fileName, bool $inline, ?string $mimeType, ?int $contentLength): StreamedResponse
+    {
+        $headers = [];
+
+        $disposition = HeaderUtils::makeDisposition(
+            $inline ? HeaderUtils::DISPOSITION_INLINE : HeaderUtils::DISPOSITION_ATTACHMENT,
+            $fileName
+        );
+
+        $headers['Content-Disposition'] = $disposition;
+
+        if ($mimeType) {
+            $headers['Content-Type'] = $mimeType;
+        }
+
+        if ($contentLength) {
+            $headers['Content-Length'] = (string) $contentLength;
+        }
+
+        return response()->stream($callback, 200, $headers);
+    }
+
+    protected function resolveStorageSize(string $disk, string $path): ?int
+    {
+        try {
+            return Storage::disk($disk)->size($path) ?: null;
+        } catch (Throwable $exception) {
+            Log::debug('AMI call history: unable to determine storage size', [
+                'disk' => $disk,
+                'path' => $path,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return null;
+        }
     }
 }

--- a/packages/behin-ami/src/Services/CallHistoryService.php
+++ b/packages/behin-ami/src/Services/CallHistoryService.php
@@ -286,14 +286,6 @@ class CallHistoryService
 
         $recordingConfig = (array) config('behin-ami.recordings', []);
 
-        $baseUrl = $recordingConfig['base_url'] ?? null;
-        if ($baseUrl) {
-            $url = rtrim($baseUrl, '/') . '/' . ltrim($recording, '/');
-            $result['available'] = true;
-            $result['download_url'] = $url;
-            $result['stream_url'] = $url;
-        }
-
         $disk = $recordingConfig['disk'] ?? null;
         $prefix = trim($recordingConfig['prefix'] ?? '', '/');
         $storagePath = ltrim($recording, '/');
@@ -334,6 +326,21 @@ class CallHistoryService
 
                 $result['available'] = true;
                 $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
+                $result['stream_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName, 'inline' => 1]);
+                $result['token'] = $token;
+            }
+        }
+
+        if (!$result['available']) {
+            $baseUrl = $recordingConfig['base_url'] ?? null;
+            if ($baseUrl) {
+                $token = $this->encodeDownloadToken([
+                    'remote_path' => ltrim($recording, '/'),
+                ]);
+
+                $result['available'] = true;
+                $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
+                $result['stream_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName, 'inline' => 1]);
                 $result['token'] = $token;
             }
         }

--- a/packages/behin-ami/src/config/behin-ami.php
+++ b/packages/behin-ami/src/config/behin-ami.php
@@ -18,5 +18,16 @@ return [
         'prefix' => env('AMI_RECORDINGS_PREFIX', ''),
         'base_path' => env('AMI_RECORDINGS_BASE_PATH'),
         'base_url' => env('AMI_RECORDINGS_BASE_URL'),
+        'issabel' => [
+            'base_url' => env('AMI_ISSABEL_BASE_URL'),
+            'username' => env('AMI_ISSABEL_USERNAME'),
+            'password' => env('AMI_ISSABEL_PASSWORD'),
+            'login_path' => env('AMI_ISSABEL_LOGIN_PATH', '/index.php?module=auth&action=login'),
+            'username_field' => env('AMI_ISSABEL_USERNAME_FIELD', 'input_user'),
+            'password_field' => env('AMI_ISSABEL_PASSWORD_FIELD', 'input_pass'),
+            'extra_fields' => [],
+            'verify_ssl' => env('AMI_ISSABEL_VERIFY_SSL', true),
+            'timeout' => env('AMI_ISSABEL_TIMEOUT', 15),
+        ],
     ],
 ];


### PR DESCRIPTION
## Summary
- add an authenticated Issabel HTTP client that logs in and streams call recordings through the Laravel controller
- route generated download and inline playback URLs through the application for local paths and remote Issabel recordings
- introduce configuration options for Issabel credentials and request handling

## Testing
- php -l packages/behin-ami/src/Controllers/CallRecordingController.php
- php -l packages/behin-ami/src/Services/CallHistoryService.php
- php -l packages/behin-ami/src/config/behin-ami.php

------
https://chatgpt.com/codex/tasks/task_e_68e1623994d88332b5cb75ab76af28ce