### PR TITLE
Enable last status filtering for all requests report

### DIFF
--- a/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/AllRequestsReportController.php
@@ -113,6 +113,17 @@ class AllRequestsReportController extends Controller
             $query->where('feasibility_study', 'like', '%' . $filters['feasibility_study'] . '%');
         }
 
+        if (!empty($filters['last_status'])) {
+            $query->whereExists(function ($subQuery) use ($filters) {
+                $subQuery->select(DB::raw(1))
+                    ->from('wf_inbox as wi')
+                    ->join('wf_task as wt', 'wt.id', '=', 'wi.task_id')
+                    ->whereColumn('wi.case_id', 'c.id')
+                    ->whereNotIn('wi.status', ['done', 'doneByOther', 'canceled'])
+                    ->where('wt.name', 'like', '%' . $filters['last_status'] . '%');
+            });
+        }
+
 
         return $query;
     }


### PR DESCRIPTION
## Summary
- ensure the all requests report query limits results by the provided last_status filter
- look up active inbox tasks for each case and match them against the requested status name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28f69631c833280488058fe2f009c