### PR TITLE
Refine user notification views with material-inspired styling

### DIFF
--- a/packages/user-notifications/src/Resources/views/admin/create.blade.php
+++ b/packages/user-notifications/src/Resources/views/admin/create.blade.php
@@ -1,98 +1,224 @@
 @extends('behin-layouts.app')
 
+@section('style')
+    <style>
+        .notification-form-wrapper {
+            max-width: 960px;
+            margin: 0 auto;
+        }
+
+        .notification-form-card {
+            border: none;
+            border-radius: 20px;
+            box-shadow: 0 22px 45px rgba(15, 76, 129, 0.18);
+            overflow: hidden;
+        }
+
+        .notification-form-header {
+            background: linear-gradient(135deg, #0f4c81 0%, #1d8cf8 100%);
+            padding: 32px 36px;
+            color: #fff;
+        }
+
+        .notification-form-header h1 {
+            font-size: 1.8rem;
+            font-weight: 700;
+            margin-bottom: 6px;
+        }
+
+        .notification-form-header p {
+            margin: 0;
+            opacity: .85;
+        }
+
+        .notification-form-body {
+            padding: 32px 36px 40px;
+            background: #fff;
+        }
+
+        .form-floating-label {
+            font-weight: 600;
+            color: #1f3a60;
+            margin-bottom: 10px;
+        }
+
+        .custom-input {
+            border-radius: 14px !important;
+            border: 1px solid rgba(31, 58, 96, 0.12);
+            padding: 12px 16px;
+            box-shadow: none;
+            transition: border-color .2s ease, box-shadow .2s ease;
+        }
+
+        .custom-input:focus {
+            border-color: #2563eb;
+            box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.2);
+        }
+
+        .custom-radio {
+            border-radius: 12px;
+            border: 1px solid rgba(31, 58, 96, 0.08);
+            padding: 14px 16px;
+            background: #f8fbff;
+            transition: all .2s ease;
+        }
+
+        .custom-radio:hover {
+            border-color: #2563eb;
+            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.15);
+        }
+
+        .options-scroll {
+            max-height: 240px;
+            overflow-y: auto;
+            border-radius: 14px;
+            border: 1px solid rgba(31, 58, 96, 0.1);
+            padding: 16px;
+            background: #fdfefe;
+        }
+
+        .options-scroll label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 12px;
+            font-weight: 500;
+        }
+
+        .btn-primary-gradient {
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            border: none;
+            color: #fff;
+            border-radius: 14px;
+            padding: 12px 32px;
+            font-weight: 600;
+            box-shadow: 0 18px 30px rgba(37, 99, 235, 0.25);
+            transition: transform .2s ease, box-shadow .2s ease;
+        }
+
+        .btn-primary-gradient:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 34px rgba(37, 99, 235, 0.3);
+        }
+
+        .form-error-text {
+            font-size: .85rem;
+            color: #dc3545;
+            margin-top: 6px;
+        }
+    </style>
+@endsection
+
 @section('content')
-    <div class="container mx-auto py-6">
-        <div class="bg-white shadow rounded-lg p-6">
-            <h1 class="text-2xl font-bold mb-4">{{ __('ارسال پیام جدید') }}</h1>
-
-            <form action="{{ route('admin.notifications.store') }}" method="POST" class="space-y-6">
-                @csrf
-                <div>
-                    <label class="block text-sm font-medium text-gray-700">{{ __('عنوان پیام') }}</label>
-                    <input type="text" name="title" value="{{ old('title') }}" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" required>
-                    @error('title')
-                        <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
-                    @enderror
+    <div class="container-fluid py-4">
+        <div class="notification-form-wrapper">
+            <div class="notification-form-card">
+                <div class="notification-form-header">
+                    <h1>{{ __('ارسال پیام جدید') }}</h1>
+                    <p>{{ __('پیام خود را با رنگ و حس متریال برای کاربران ارسال کنید') }}</p>
                 </div>
+                <div class="notification-form-body">
+                    <form action="{{ route('admin.notifications.store') }}" method="POST">
+                        @csrf
+                        <div class="mb-4">
+                            <label class="form-floating-label">{{ __('عنوان پیام') }}</label>
+                            <input type="text" name="title" value="{{ old('title') }}" class="form-control custom-input" required>
+                            @error('title')
+                                <p class="form-error-text">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                <div>
-                    <label class="block text-sm font-medium text-gray-700">{{ __('متن پیام') }}</label>
-                    <textarea name="message" rows="6" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500" required>{{ old('message') }}</textarea>
-                    @error('message')
-                        <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
-                    @enderror
-                </div>
+                        <div class="mb-4">
+                            <label class="form-floating-label">{{ __('متن پیام') }}</label>
+                            <textarea name="message" rows="6" class="form-control custom-input" required>{{ old('message') }}</textarea>
+                            @error('message')
+                                <p class="form-error-text">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                <div>
-                    <label class="block text-sm font-medium text-gray-700 mb-2">{{ __('ارسال برای') }}</label>
-                    <div class="space-y-2">
-                        <label class="flex items-center space-x-2 space-x-reverse">
-                            <input type="radio" name="recipient_type" value="user" {{ old('recipient_type') === 'user' ? 'checked' : '' }}>
-                            <span>{{ __('یک کاربر خاص') }}</span>
-                        </label>
-                        <label class="flex items-center space-x-2 space-x-reverse">
-                            <input type="radio" name="recipient_type" value="users" {{ old('recipient_type') === 'users' ? 'checked' : '' }}>
-                            <span>{{ __('چند کاربر خاص') }}</span>
-                        </label>
-                        <label class="flex items-center space-x-2 space-x-reverse">
-                            <input type="radio" name="recipient_type" value="roles" {{ old('recipient_type') === 'roles' ? 'checked' : '' }}>
-                            <span>{{ __('یک یا چند نقش') }}</span>
-                        </label>
-                        <label class="flex items-center space-x-2 space-x-reverse">
-                            <input type="radio" name="recipient_type" value="all" {{ old('recipient_type', 'all') === 'all' ? 'checked' : '' }}>
-                            <span>{{ __('همه کاربران') }}</span>
-                        </label>
-                    </div>
-                    @error('recipient_type')
-                        <p class="text-sm text-red-600 mt-1">{{ $message }}</p>
-                    @enderror
-                </div>
+                        <div class="mb-4">
+                            <label class="form-floating-label mb-3">{{ __('ارسال برای') }}</label>
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label class="custom-radio w-100">
+                                        <input type="radio" class="form-check-input me-2" name="recipient_type" value="user" {{ old('recipient_type') === 'user' ? 'checked' : '' }}>
+                                        <span>{{ __('یک کاربر خاص') }}</span>
+                                    </label>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="custom-radio w-100">
+                                        <input type="radio" class="form-check-input me-2" name="recipient_type" value="users" {{ old('recipient_type') === 'users' ? 'checked' : '' }}>
+                                        <span>{{ __('چند کاربر خاص') }}</span>
+                                    </label>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="custom-radio w-100">
+                                        <input type="radio" class="form-check-input me-2" name="recipient_type" value="roles" {{ old('recipient_type') === 'roles' ? 'checked' : '' }}>
+                                        <span>{{ __('یک یا چند نقش') }}</span>
+                                    </label>
+                                </div>
+                                <div class="col-md-6">
+                                    <label class="custom-radio w-100">
+                                        <input type="radio" class="form-check-input me-2" name="recipient_type" value="all" {{ old('recipient_type', 'all') === 'all' ? 'checked' : '' }}>
+                                        <span>{{ __('همه کاربران') }}</span>
+                                    </label>
+                                </div>
+                            </div>
+                            @error('recipient_type')
+                                <p class="form-error-text">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                <div id="user-select" class="hidden">
-                    <label class="block text-sm font-medium text-gray-700">{{ __('انتخاب کاربر') }}</label>
-                    <select name="user_id" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
-                        <option value="">{{ __('انتخاب کنید') }}</option>
-                        @foreach($users as $user)
-                            <option value="{{ $user->id }}" {{ old('user_id') == $user->id ? 'selected' : '' }}>{{ $user->name }}</option>
-                        @endforeach
-                    </select>
-                </div>
+                        <div id="user-select" class="mb-4 d-none">
+                            <label class="form-floating-label">{{ __('انتخاب کاربر') }}</label>
+                            <select name="user_id" class="form-select custom-input">
+                                <option value="">{{ __('انتخاب کنید') }}</option>
+                                @foreach($users as $user)
+                                    <option value="{{ $user->id }}" {{ old('user_id') == $user->id ? 'selected' : '' }}>{{ $user->name }}</option>
+                                @endforeach
+                            </select>
+                        </div>
 
-                <div id="users-select" class="hidden">
-                    <label class="block text-sm font-medium text-gray-700">{{ __('انتخاب چند کاربر') }}</label>
-                    <div class="max-h-56 overflow-y-auto border border-gray-200 rounded-md p-3 space-y-2">
-                        @foreach($users as $user)
-                            <label class="flex items-center space-x-2 space-x-reverse">
-                                <input type="checkbox" name="user_ids[]" value="{{ $user->id }}" {{ in_array($user->id, old('user_ids', [])) ? 'checked' : '' }}>
-                                <span>{{ $user->name }}</span>
-                            </label>
-                        @endforeach
-                    </div>
-                </div>
+                        <div id="users-select" class="mb-4 d-none">
+                            <label class="form-floating-label">{{ __('انتخاب چند کاربر') }}</label>
+                            <div class="options-scroll">
+                                @foreach($users as $user)
+                                    <label>
+                                        <input type="checkbox" class="form-check-input me-2" name="user_ids[]" value="{{ $user->id }}" {{ in_array($user->id, old('user_ids', [])) ? 'checked' : '' }}>
+                                        <span>{{ $user->name }}</span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        </div>
 
-                <div id="roles-select" class="hidden">
-                    <label class="block text-sm font-medium text-gray-700">{{ __('انتخاب نقش‌ها') }}</label>
-                    <div class="max-h-56 overflow-y-auto border border-gray-200 rounded-md p-3 space-y-2">
-                        @forelse($roles as $role)
-                            <label class="flex items-center space-x-2 space-x-reverse">
-                                <input type="checkbox" name="role_ids[]" value="{{ $role->id }}" {{ in_array($role->id, old('role_ids', [])) ? 'checked' : '' }}>
-                                <span>{{ $role->name }}</span>
-                            </label>
-                        @empty
-                            <p class="text-sm text-gray-500">{{ __('هیچ نقشی یافت نشد.') }}</p>
-                        @endforelse
-                    </div>
-                </div>
+                        <div id="roles-select" class="mb-4 d-none">
+                            <label class="form-floating-label">{{ __('انتخاب نقش‌ها') }}</label>
+                            <div class="options-scroll">
+                                @forelse($roles as $role)
+                                    <label>
+                                        <input type="checkbox" class="form-check-input me-2" name="role_ids[]" value="{{ $role->id }}" {{ in_array($role->id, old('role_ids', [])) ? 'checked' : '' }}>
+                                        <span>{{ $role->name }}</span>
+                                    </label>
+                                @empty
+                                    <p class="text-muted mb-0">{{ __('هیچ نقشی یافت نشد.') }}</p>
+                                @endforelse
+                            </div>
+                        </div>
 
-                <div class="flex justify-end">
-                    <button type="submit" class="px-6 py-2 bg-indigo-600 text-white rounded-md">{{ __('ارسال پیام') }}</button>
+                        <div class="d-flex justify-content-end">
+                            <button type="submit" class="btn btn-primary-gradient">
+                                <i class="fa fa-send ms-2"></i>
+                                {{ __('ارسال پیام') }}
+                            </button>
+                        </div>
+                    </form>
                 </div>
-            </form>
+            </div>
         </div>
     </div>
 @endsection
 
-@push('scripts')
+@section('script')
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const typeInputs = document.querySelectorAll('input[name="recipient_type"]');
@@ -102,13 +228,13 @@
 
             const toggle = () => {
                 const value = document.querySelector('input[name="recipient_type"]:checked')?.value;
-                userSelect.classList.toggle('hidden', value !== 'user');
-                usersSelect.classList.toggle('hidden', value !== 'users');
-                rolesSelect.classList.toggle('hidden', value !== 'roles');
+                userSelect.classList.toggle('d-none', value !== 'user');
+                usersSelect.classList.toggle('d-none', value !== 'users');
+                rolesSelect.classList.toggle('d-none', value !== 'roles');
             };
 
             typeInputs.forEach(input => input.addEventListener('change', toggle));
             toggle();
         });
     </script>
-@endpush
+@endsection

--- a/packages/user-notifications/src/Resources/views/admin/index.blade.php
+++ b/packages/user-notifications/src/Resources/views/admin/index.blade.php
@@ -1,46 +1,131 @@
 @extends('behin-layouts.app')
 
+@section('style')
+    <style>
+        .notifications-hero {
+            background: linear-gradient(135deg, #0f4c81 0%, #1d8cf8 100%);
+            border-radius: 18px;
+            color: #fff;
+            padding: 28px 32px;
+            box-shadow: 0 20px 45px rgba(15, 76, 129, 0.35);
+        }
+
+        .notifications-hero h1 {
+            font-size: 1.75rem;
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .notifications-hero p {
+            margin: 0;
+            opacity: 0.9;
+            font-size: .95rem;
+        }
+
+        .notifications-card {
+            border: none;
+            border-radius: 16px;
+            box-shadow: 0 16px 32px rgba(20, 69, 120, 0.12);
+            overflow: hidden;
+        }
+
+        .notifications-table thead {
+            background: #f3f6fb;
+        }
+
+        .notifications-table th {
+            color: #3a4a66;
+            font-size: .82rem;
+            letter-spacing: .04em;
+        }
+
+        .notifications-table tbody tr {
+            transition: all .2s ease-in-out;
+        }
+
+        .notifications-table tbody tr:hover {
+            transform: translateY(-1px);
+            box-shadow: inset 5px 0 0 #1d8cf8;
+            background-color: #f8fbff;
+        }
+
+        .btn-primary-gradient {
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            border: none;
+            color: #fff !important;
+            box-shadow: 0 12px 24px rgba(37, 99, 235, 0.3);
+            transition: transform .2s ease, box-shadow .2s ease;
+        }
+
+        .btn-primary-gradient:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
+        }
+
+        .notifications-pagination .page-item.active .page-link {
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            border-color: transparent;
+        }
+
+        .notifications-pagination .page-link {
+            border-radius: 10px;
+            margin: 0 4px;
+            color: #1f3a60;
+        }
+    </style>
+@endsection
+
 @section('content')
-    <div class="container mx-auto py-6">
-        <div class="flex items-center justify-between mb-4">
-            <h1 class="text-2xl font-bold">{{ __('مدیریت پیام‌ها') }}</h1>
-            <a href="{{ route('admin.notifications.create') }}" class="px-4 py-2 bg-indigo-600 text-white rounded-md">{{ __('ایجاد پیام جدید') }}</a>
+    <div class="container-fluid py-4">
+        <div class="notifications-hero mb-4 d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+            <div>
+                <h1>{{ __('مدیریت پیام‌ها') }}</h1>
+                <p>{{ __('کنترل و پایش پیام‌های ارسالی برای کاربران سامانه') }}</p>
+            </div>
+            <a href="{{ route('admin.notifications.create') }}" class="btn btn-primary-gradient px-4 py-2 rounded-pill d-inline-flex align-items-center gap-2">
+                <i class="fa fa-paper-plane"></i>
+                <span>{{ __('ایجاد پیام جدید') }}</span>
+            </a>
         </div>
 
-        <div class="bg-white shadow rounded-lg overflow-hidden">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('عنوان') }}</th>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('ارسال کننده') }}</th>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('دریافت کننده') }}</th>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('تاریخ ارسال') }}</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    @forelse ($notifications as $notification)
-                        <tr>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $notification->title }}</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($notification->sender)->name ?? __('سیستم') }}</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                @if($notification->receiver_id)
-                                    {{ optional($notification->receiver)->name ?? __('کاربر حذف شده') }}
-                                @else
-                                    {{ $notification->receiver_role === 'all' ? __('همه کاربران') : __('چند کاربر/نقش') }}
-                                @endif
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($notification->created_at)->format('Y/m/d H:i') }}</td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="4" class="px-6 py-4 text-center text-gray-500">{{ __('پیامی ارسال نشده است.') }}</td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
+        <div class="card notifications-card">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0 notifications-table align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('عنوان') }}</th>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('ارسال کننده') }}</th>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('دریافت کننده') }}</th>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('تاریخ ارسال') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($notifications as $notification)
+                                <tr>
+                                    <td class="px-4 py-3 fw-semibold text-dark">{{ $notification->title }}</td>
+                                    <td class="px-4 py-3 text-muted">{{ optional($notification->sender)->name ?? __('سیستم') }}</td>
+                                    <td class="px-4 py-3 text-muted">
+                                        @if($notification->receiver_id)
+                                            {{ optional($notification->receiver)->name ?? __('کاربر حذف شده') }}
+                                        @else
+                                            {{ $notification->receiver_role === 'all' ? __('همه کاربران') : __('چند کاربر/نقش') }}
+                                        @endif
+                                    </td>
+                                    <td class="px-4 py-3 text-muted">{{ optional($notification->created_at)->format('Y/m/d H:i') }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="px-4 py-4 text-center text-muted">{{ __('پیامی ارسال نشده است.') }}</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
 
-        <div class="mt-4">
+        <div class="notifications-pagination mt-4">
             {{ $notifications->links() }}
         </div>
     </div>

--- a/packages/user-notifications/src/Resources/views/user/index.blade.php
+++ b/packages/user-notifications/src/Resources/views/user/index.blade.php
@@ -1,48 +1,152 @@
 @extends('behin-layouts.app')
 
+@section('style')
+    <style>
+        .user-notifications-hero {
+            background: linear-gradient(135deg, #0f4c81 0%, #1d8cf8 100%);
+            border-radius: 22px;
+            padding: 26px 32px;
+            color: #fff;
+            box-shadow: 0 20px 40px rgba(15, 76, 129, 0.28);
+        }
+
+        .user-notifications-hero h1 {
+            margin-bottom: 6px;
+            font-weight: 700;
+        }
+
+        .user-notifications-hero p {
+            margin: 0;
+            opacity: .85;
+        }
+
+        .user-notifications-card {
+            border: none;
+            border-radius: 20px;
+            box-shadow: 0 24px 44px rgba(31, 58, 96, 0.15);
+            overflow: hidden;
+        }
+
+        .user-notifications-table thead {
+            background-color: #f3f6fb;
+        }
+
+        .user-notifications-table th {
+            color: #1f3a60;
+            font-size: .85rem;
+            letter-spacing: .04em;
+        }
+
+        .user-notifications-table tbody tr {
+            transition: all .2s ease;
+        }
+
+        .user-notifications-table tbody tr.unread {
+            background: rgba(29, 140, 248, 0.08);
+        }
+
+        .user-notifications-table tbody tr:hover {
+            transform: translateY(-2px);
+            box-shadow: inset 4px 0 0 #1d8cf8;
+            background-color: #f8fbff;
+        }
+
+        .badge-soft-success {
+            background: rgba(34, 197, 94, .15);
+            color: #15803d;
+            border-radius: 999px;
+            padding: .45rem 1.1rem;
+            font-weight: 600;
+        }
+
+        .badge-soft-danger {
+            background: rgba(248, 113, 113, .18);
+            color: #b91c1c;
+            border-radius: 999px;
+            padding: .45rem 1.1rem;
+            font-weight: 600;
+        }
+
+        .link-material {
+            color: #2563eb;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            transition: gap .2s ease;
+        }
+
+        .link-material:hover {
+            color: #1740ad;
+            gap: 10px;
+        }
+
+        .notifications-pagination .page-item.active .page-link {
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            border-color: transparent;
+        }
+
+        .notifications-pagination .page-link {
+            border-radius: 12px;
+            margin: 0 4px;
+            color: #1f3a60;
+        }
+    </style>
+@endsection
+
 @section('content')
-    <div class="container mx-auto py-6">
-        <div class="flex items-center justify-between mb-4">
-            <h1 class="text-2xl font-bold">{{ __('پیام‌ها') }}</h1>
+    <div class="container-fluid py-4">
+        <div class="user-notifications-hero d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+            <div>
+                <h1 class="h3 mb-1">{{ __('پیام‌های شما') }}</h1>
+                <p>{{ __('همه اعلان‌های دریافت شده از سوی سامانه را در یک نگاه مدیریت کنید') }}</p>
+            </div>
             <x-user-notifications::unread-indicator :count="$unreadCount" />
         </div>
 
-        <div class="bg-white shadow rounded-lg overflow-hidden">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('عنوان') }}</th>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('تاریخ ارسال') }}</th>
-                        <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{{ __('وضعیت') }}</th>
-                        <th class="px-6 py-3"></th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    @forelse ($notifications as $notification)
-                        <tr class="{{ $notification->is_read ? '' : 'bg-blue-50' }}">
-                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{{ $notification->title }}</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ optional($notification->created_at)->format('Y/m/d H:i') }}</td>
-                            <td class="px-6 py-4 whitespace-nowrap text-sm">
-                                @if($notification->is_read)
-                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">{{ __('خوانده شده') }}</span>
-                                @else
-                                    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">{{ __('خوانده نشده') }}</span>
-                                @endif
-                            </td>
-                            <td class="px-6 py-4 whitespace-nowrap text-left text-sm font-medium">
-                                <a href="{{ route('notifications.show', $notification) }}" class="text-indigo-600 hover:text-indigo-900">{{ __('مشاهده') }}</a>
-                            </td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="4" class="px-6 py-4 text-center text-gray-500">{{ __('پیامی برای نمایش وجود ندارد.') }}</td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
+        <div class="card user-notifications-card">
+            <div class="card-body p-0">
+                <div class="table-responsive">
+                    <table class="table user-notifications-table mb-0 align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('عنوان') }}</th>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('تاریخ ارسال') }}</th>
+                                <th scope="col" class="text-end px-4 py-3">{{ __('وضعیت') }}</th>
+                                <th scope="col" class="px-4 py-3"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($notifications as $notification)
+                                <tr class="{{ $notification->is_read ? '' : 'unread' }}">
+                                    <td class="px-4 py-3 fw-semibold text-dark">{{ $notification->title }}</td>
+                                    <td class="px-4 py-3 text-muted">{{ optional($notification->created_at)->format('Y/m/d H:i') }}</td>
+                                    <td class="px-4 py-3">
+                                        @if($notification->is_read)
+                                            <span class="badge-soft-success">{{ __('خوانده شده') }}</span>
+                                        @else
+                                            <span class="badge-soft-danger">{{ __('خوانده نشده') }}</span>
+                                        @endif
+                                    </td>
+                                    <td class="px-4 py-3 text-start">
+                                        <a href="{{ route('notifications.show', $notification) }}" class="link-material">
+                                            <span>{{ __('مشاهده') }}</span>
+                                            <i class="fa fa-arrow-left"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="px-4 py-4 text-center text-muted">{{ __('پیامی برای نمایش وجود ندارد.') }}</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
 
-        <div class="mt-4">
+        <div class="notifications-pagination mt-4">
             {{ $notifications->links() }}
         </div>
     </div>

--- a/packages/user-notifications/src/Resources/views/user/show.blade.php
+++ b/packages/user-notifications/src/Resources/views/user/show.blade.php
@@ -1,29 +1,123 @@
 @extends('behin-layouts.app')
 
+@section('style')
+    <style>
+        .notification-detail-wrapper {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+
+        .notification-detail-card {
+            border: none;
+            border-radius: 24px;
+            overflow: hidden;
+            box-shadow: 0 30px 60px rgba(15, 76, 129, 0.18);
+        }
+
+        .notification-detail-header {
+            background: linear-gradient(135deg, #0f4c81 0%, #1d8cf8 100%);
+            padding: 34px 40px;
+            color: #fff;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .notification-detail-header h1 {
+            font-size: 2rem;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        .notification-detail-header span {
+            font-size: .95rem;
+            opacity: .85;
+        }
+
+        .notification-detail-body {
+            background: #fff;
+            padding: 36px 40px 42px;
+        }
+
+        .notification-content {
+            font-size: 1rem;
+            line-height: 1.9;
+            color: #1f3a60;
+        }
+
+        .btn-outline-material {
+            border-radius: 50px;
+            border: 2px solid #2563eb;
+            color: #2563eb;
+            font-weight: 600;
+            padding: 10px 24px;
+            transition: all .2s ease;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .btn-outline-material:hover {
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            color: #fff;
+            border-color: transparent;
+            box-shadow: 0 16px 28px rgba(37, 99, 235, 0.25);
+        }
+
+        .btn-solid-material {
+            border: none;
+            border-radius: 50px;
+            background: linear-gradient(135deg, #2563eb 0%, #1d8cf8 100%);
+            color: #fff;
+            font-weight: 600;
+            padding: 10px 28px;
+            box-shadow: 0 18px 32px rgba(37, 99, 235, 0.25);
+            transition: transform .2s ease, box-shadow .2s ease;
+        }
+
+        .btn-solid-material:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 36px rgba(37, 99, 235, 0.3);
+        }
+
+        .notification-actions {
+            display: flex;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+    </style>
+@endsection
+
 @section('content')
-    <div class="container mx-auto py-6">
-        <div class="bg-white shadow rounded-lg p-6">
-            <div class="flex items-start justify-between mb-4">
-                <div>
-                    <h1 class="text-2xl font-bold text-gray-800">{{ $notification->title }}</h1>
-                    <p class="text-sm text-gray-500 mt-1">
-                        {{ __('ارسال شده در :date', ['date' => optional($notification->created_at)->format('Y/m/d H:i')]) }}
-                    </p>
+    <div class="container-fluid py-4">
+        <div class="notification-detail-wrapper">
+            <div class="notification-detail-card">
+                <div class="notification-detail-header">
+                    <h1>{{ $notification->title }}</h1>
+                    <span>{{ __('ارسال شده در :date', ['date' => optional($notification->created_at)->format('Y/m/d H:i')]) }}</span>
                 </div>
-                @if(!$notification->is_read)
-                    <form action="{{ route('notifications.mark', $notification) }}" method="POST">
-                        @csrf
-                        <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-md">{{ __('علامت به عنوان خوانده شده') }}</button>
-                    </form>
-                @endif
-            </div>
+                <div class="notification-detail-body">
+                    <div class="notification-content">
+                        {!! nl2br(e($notification->message)) !!}
+                    </div>
 
-            <div class="prose max-w-none leading-relaxed text-gray-700">
-                {!! nl2br(e($notification->message)) !!}
-            </div>
+                    <div class="notification-actions mt-4">
+                        <a href="{{ route('notifications.index') }}" class="btn btn-outline-material">
+                            <i class="fa fa-arrow-right"></i>
+                            {{ __('بازگشت به لیست پیام‌ها') }}
+                        </a>
 
-            <div class="mt-6">
-                <a href="{{ route('notifications.index') }}" class="text-indigo-600 hover:text-indigo-800">{{ __('بازگشت به لیست پیام‌ها') }}</a>
+                        @if(!$notification->is_read)
+                            <form action="{{ route('notifications.mark', $notification) }}" method="POST">
+                                @csrf
+                                <button type="submit" class="btn btn-solid-material">
+                                    <i class="fa fa-check ms-1"></i>
+                                    {{ __('علامت به عنوان خوانده شده') }}
+                                </button>
+                            </form>
+                        @endif
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle the admin notification list with a gradient hero, elevated card table, and updated pagination
- redesign the notification creation form with material-inspired controls, gradients, and improved toggles
- refresh user notification listing and detail pages with cohesive gradients, badges, and action buttons aligned to the login palette

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38e5351f483328ea15175240ccec7