### PR TITLE
Add reminders to workflow inbox tasks

### DIFF
--- a/packages/behin-simple-workflow/src/Controllers/Core/InboxController.php
+++ b/packages/behin-simple-workflow/src/Controllers/Core/InboxController.php
@@ -22,12 +22,54 @@ use Behin\SimpleWorkflow\Jobs\SendPushNotification;
 use Behin\SimpleWorkflow\Models\Entities\CasesManual;
 use Behin\SimpleWorkflow\Models\Core\Variable;
 use Illuminate\Support\Str;
+use Behin\SimpleWorkflow\Jobs\SendTaskReminderNotification;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
 
 class InboxController extends Controller
 {
     public static function getById($id)
     {
         return Inbox::find($id);
+    }
+
+    public function storeReminder(Request $request, string $inboxId): JsonResponse
+    {
+        $inbox = Inbox::with(['task', 'case'])->findOrFail($inboxId);
+
+        if ($inbox->actor !== Auth::id()) {
+            abort(403, trans('fields.You cannot set reminder for this task'));
+        }
+
+        $data = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'message' => ['nullable', 'string'],
+            'remind_at' => ['required', 'date', 'after:now'],
+        ], [], [
+            'title' => trans('fields.Reminder Title'),
+            'message' => trans('fields.Reminder Message'),
+            'remind_at' => trans('fields.Reminder At'),
+        ]);
+
+        $remindAt = Carbon::parse($data['remind_at'], config('app.timezone'));
+
+        $caseName = $inbox->case_name ?: optional($inbox->case)->number;
+        $taskName = optional($inbox->task)->name;
+
+        SendTaskReminderNotification::dispatch(
+            $inbox->id,
+            (int) $inbox->actor,
+            Auth::id(),
+            $data['title'],
+            $data['message'] ?? null,
+            $caseName ? (string) $caseName : null,
+            $taskName ? (string) $taskName : null,
+        )->delay($remindAt);
+
+        return response()->json([
+            'status' => 200,
+            'msg' => trans('fields.Reminder scheduled successfully'),
+        ]);
     }
 
     public static function create($taskId, $caseId, $actor, $status = 'new', $caseName = null)

--- a/packages/behin-simple-workflow/src/Jobs/SendTaskReminderNotification.php
+++ b/packages/behin-simple-workflow/src/Jobs/SendTaskReminderNotification.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Behin\SimpleWorkflow\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use UserNotifications\Events\NotificationSent;
+use UserNotifications\Models\Notification;
+
+class SendTaskReminderNotification implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public string $inboxId,
+        public int $receiverId,
+        public ?int $senderId,
+        public string $title,
+        public ?string $message,
+        public ?string $caseName,
+        public ?string $taskName,
+    ) {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $body = trim((string) ($this->message ?? ''));
+
+        if ($body === '') {
+            $body = trans('fields.Reminder default message', [
+                'task' => (string) ($this->taskName ?? ''),
+                'case' => (string) ($this->caseName ?? ''),
+            ]);
+        }
+
+        $linkLabel = trans('fields.Reminder Link Label');
+        $link = route('simpleWorkflow.inbox.view', ['inboxId' => $this->inboxId]);
+
+        $payload = [
+            'title' => $this->title,
+            'message' => trim($body . PHP_EOL . PHP_EOL . $linkLabel . ': ' . $link),
+            'sender_id' => $this->senderId,
+            'receiver_id' => $this->receiverId,
+        ];
+
+        $notification = Notification::create($payload);
+
+        NotificationSent::dispatch($notification);
+    }
+}

--- a/packages/behin-simple-workflow/src/Lang/fa/fields.php
+++ b/packages/behin-simple-workflow/src/Lang/fa/fields.php
@@ -124,4 +124,17 @@ return [
     'Filter Operator Is Empty' => 'خالی باشد',
     'Filter Operator Is Not Empty' => 'خالی نباشد',
 
+    'Add Reminder' => 'افزودن یادآوری',
+    'Reminder Title' => 'عنوان یادآوری',
+    'Reminder Message' => 'پیام یادآوری',
+    'Reminder At' => 'زمان یادآوری',
+    'Send Reminder' => 'ثبت یادآوری',
+    'Reminder scheduled successfully' => 'یادآوری با موفقیت ثبت شد.',
+    'Reminder default message' => 'یادآوری برای تسک :task در پرونده :case',
+    'Reminder Link Label' => 'مشاهده تسک',
+    'You cannot set reminder for this task' => 'شما دسترسی لازم برای ثبت یادآوری این تسک را ندارید.',
+    'Unknown error' => 'خطای ناشناخته رخ داد.',
+    'Cancel' => 'انصراف',
+    'Close' => 'بستن',
+
 ];

--- a/packages/behin-simple-workflow/src/Routes/web.php
+++ b/packages/behin-simple-workflow/src/Routes/web.php
@@ -81,6 +81,7 @@ Route::name('simpleWorkflow.')->prefix('workflow')->middleware(['web', 'auth'])-
         // Route::get('all-inbox', [ InboxController::class, 'getAllInbox' ])->name('getAllInbox');
         Route::get('cases', [ InboxController::class, 'showCases' ])->name('cases.list');
         Route::get('cases/{caseId}/inboxes', [ InboxController::class, 'showInboxes' ])->name('cases.inboxes');
+        Route::post('{inbox}/reminders', [ InboxController::class, 'storeReminder' ])->name('reminders.store');
 
         Route::get('edit/{inboxId}', [ InboxController::class, 'edit' ])->name('edit');
         Route::put('update/{inboxId}', [ InboxController::class, 'update' ])->name('update');

--- a/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
+++ b/packages/behin-simple-workflow/src/Views/Core/Inbox/show.blade.php
@@ -105,6 +105,11 @@
                     {{ trans('fields.Send Manully') }}
                 </button>
 
+                <button class="md-btn md-btn-secondary" type="button" onclick="openReminderModal()">
+                    <i class="material-icons">alarm</i>
+                    {{ trans('fields.Add Reminder') }}
+                </button>
+
                 @if ($task->show_save_button)
                     <button class="md-btn md-btn-primary" onclick="saveForm()">
                         <i class="material-icons">save</i>
@@ -117,6 +122,40 @@
                     {{ trans('fields.Save and next') }}
                 </button>
             @endif
+        </div>
+
+        <div class="modal fade" id="reminderModal" tabindex="-1" role="dialog" aria-labelledby="reminderModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="reminderModalLabel">{{ trans('fields.Add Reminder') }}</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans('fields.Close') }}">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <form id="reminderForm" action="{{ route('simpleWorkflow.inbox.reminders.store', $inbox->id) }}" method="POST">
+                        @csrf
+                        <div class="modal-body">
+                            <div class="form-group">
+                                <label for="reminder-title" class="col-form-label">{{ trans('fields.Reminder Title') }}</label>
+                                <input type="text" class="form-control" id="reminder-title" name="title" maxlength="255" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="reminder-message" class="col-form-label">{{ trans('fields.Reminder Message') }}</label>
+                                <textarea class="form-control" id="reminder-message" name="message" rows="3"></textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="reminder-at" class="col-form-label">{{ trans('fields.Reminder At') }}</label>
+                                <input type="datetime-local" class="form-control" id="reminder-at" name="remind_at" required min="{{ now()->format('Y-m-d\TH:i') }}" value="{{ now()->addMinutes(5)->format('Y-m-d\TH:i') }}">
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">{{ trans('fields.Cancel') }}</button>
+                            <button type="submit" class="btn btn-primary">{{ trans('fields.Send Reminder') }}</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
 
         <style>
@@ -169,6 +208,10 @@
                 color: #212121;
             }
 
+            .md-btn-secondary {
+                background-color: #607d8b;
+            }
+
             .md-btn-primary {
                 background-color: #3F51B5;
             }
@@ -215,6 +258,50 @@
     <script>
         // initial_view()
         $('#mobile-navigation').fadeOut(1000)
+
+        function formatDateTimeLocal(date) {
+            const pad = (value) => String(value).padStart(2, '0');
+            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+        }
+
+        function openReminderModal() {
+            const modal = $('#reminderModal');
+            const input = modal.find('#reminder-at');
+            const now = new Date();
+            input.attr('min', formatDateTimeLocal(now));
+            const defaultDate = new Date(now.getTime() + 5 * 60 * 1000);
+            input.val(formatDateTimeLocal(defaultDate));
+            modal.modal('show');
+        }
+
+        $('#reminderForm').on('submit', function(event) {
+            event.preventDefault();
+            const form = this;
+            const fd = new FormData(form);
+            send_ajax_formdata_request(form.action, fd, function(response) {
+                if (response.status === 200) {
+                    show_message(response.msg);
+                    form.reset();
+                    $('#reminderModal').modal('hide');
+                } else {
+                    show_error(response.msg || '{{ trans('fields.Unknown error') }}');
+                }
+            }, function(xhr) {
+                hide_loading();
+                if (xhr.responseJSON && xhr.responseJSON.errors) {
+                    const messages = Object.values(xhr.responseJSON.errors).flat();
+                    show_error(messages.join('<br>'));
+                    return;
+                }
+
+                if (xhr.responseJSON && xhr.responseJSON.message) {
+                    show_error(xhr.responseJSON.message);
+                    return;
+                }
+
+                show_error('{{ trans('fields.Unknown error') }}');
+            });
+        });
 
         function createCaseNumberAndSave() {
             var form = $('#form')[0];


### PR DESCRIPTION
## Summary
- add an authenticated inbox reminder endpoint that validates scheduling data and queues a delayed job
- create a queued job that sends user notifications with links back to the workflow inbox task when reminders fire
- update the inbox view with a reminder modal, button styling, and Farsi translations for the new feature

## Testing
- php -l packages/behin-simple-workflow/src/Jobs/SendTaskReminderNotification.php
- php -l packages/behin-simple-workflow/src/Controllers/Core/InboxController.php

------
https://chatgpt.com/codex/tasks/task_e_68e3916f5860833294564610f8554fb0