### PR TITLE
Fix AMI call direction classification for workflow report

### DIFF
--- a/packages/behin-ami/src/Services/CallHistoryService.php
+++ b/packages/behin-ami/src/Services/CallHistoryService.php
@@ -152,12 +152,12 @@ class CallHistoryService
             $direction = 'unknown';
             $sourceNormalized = $this->normalizeForComparison($source);
             if ($source && in_array($sourceNormalized, $normalizedNumbers, true)) {
-                $direction = 'outbound';
+                $direction = 'inbound';
             }
 
             $destinationNormalized = $this->normalizeForComparison($destination);
             if ($direction === 'unknown' && $destination && in_array($destinationNormalized, $normalizedNumbers, true)) {
-                $direction = 'inbound';
+                $direction = 'outbound';
             }
 
             $counterparty = $direction === 'outbound'


### PR DESCRIPTION
## Summary
- correct the AMI call history direction detection so customer-originated calls are marked as inbound
- ensure calls initiated by the organization are marked as outbound when the destination matches the searched numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e62ee04b5c833285a27fb566c6d9b5