### PR TITLE
Use Issabel download script for remote recordings

### DIFF
--- a/config/behin-ami.php
+++ b/config/behin-ami.php
@@ -18,6 +18,13 @@ return [
         'prefix' => env('AMI_RECORDINGS_PREFIX', ''),
         'base_path' => env('AMI_RECORDINGS_BASE_PATH'),
         'base_url' => env('AMI_RECORDINGS_BASE_URL'),
+        'download' => [
+            'url' => env('AMI_RECORDINGS_DOWNLOAD_URL'),
+            'username' => env('AMI_RECORDINGS_DOWNLOAD_USERNAME'),
+            'password' => env('AMI_RECORDINGS_DOWNLOAD_PASSWORD'),
+            'verify_ssl' => env('AMI_RECORDINGS_DOWNLOAD_VERIFY_SSL', false),
+            'timeout' => env('AMI_RECORDINGS_DOWNLOAD_TIMEOUT'),
+        ],
         'issabel' => [
             'base_url' => env('AMI_ISSABEL_BASE_URL'),
             'username' => env('AMI_ISSABEL_USERNAME'),

--- a/packages/behin-ami/src/Controllers/CallRecordingController.php
+++ b/packages/behin-ami/src/Controllers/CallRecordingController.php
@@ -74,6 +74,11 @@ class CallRecordingController
         }
 
         if ($remotePath) {
+            $downloadConfig = (array) config('behin-ami.recordings.download', []);
+            if (!empty($downloadConfig['url'])) {
+                return $this->streamFromDownloadScript($remotePath, $fileName, $inline, $downloadConfig);
+            }
+
             return $this->streamFromIssabel($remotePath, $fileName, $inline);
         }
 
@@ -122,6 +127,67 @@ class CallRecordingController
                 fclose($handle);
             }
         }, $fileName, true, $mimeType, $fileSize);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    protected function streamFromDownloadScript(string $remotePath, string $fileName, bool $inline, array $config): StreamedResponse
+    {
+        $url = (string) ($config['url'] ?? '');
+        if ($url === '') {
+            abort(404);
+        }
+
+        $username = $config['username'] ?? null;
+        $password = $config['password'] ?? null;
+        $verifySsl = array_key_exists('verify_ssl', $config) ? (bool) $config['verify_ssl'] : true;
+        $timeout = (int) ($config['timeout'] ?? 15);
+
+        $clientOptions = [
+            'timeout' => max($timeout, 1),
+            'http_errors' => false,
+            'verify' => $verifySsl,
+        ];
+
+        if ($username !== null && $password !== null) {
+            $clientOptions['auth'] = [$username, $password];
+        }
+
+        $client = new Client($clientOptions);
+
+        try {
+            $response = $client->get($url, [
+                'query' => ['file' => $remotePath],
+                'stream' => true,
+            ]);
+        } catch (GuzzleException $exception) {
+            Log::warning('AMI call history: Issabel download script request failed', [
+                'exception' => $exception->getMessage(),
+                'path' => $remotePath,
+            ]);
+
+            abort(404);
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            Log::warning('AMI call history: Issabel download script returned unexpected status', [
+                'status' => $response->getStatusCode(),
+                'path' => $remotePath,
+            ]);
+
+            abort(404);
+        }
+
+        $body = $response->getBody();
+        $mimeType = $response->getHeaderLine('Content-Type') ?: 'audio/wav';
+        $contentLength = $response->getHeaderLine('Content-Length') ?: null;
+
+        return $this->streamResponse(function () use ($body) {
+            while (!$body->eof()) {
+                echo $body->read(8192);
+            }
+        }, $fileName, $inline, $mimeType, $contentLength ? (int) $contentLength : null);
     }
 
     protected function streamFromIssabel(string $remotePath, string $fileName, bool $inline): StreamedResponse

--- a/packages/behin-ami/src/Services/CallHistoryService.php
+++ b/packages/behin-ami/src/Services/CallHistoryService.php
@@ -331,6 +331,18 @@ class CallHistoryService
             }
         }
 
+        $downloadConfig = (array) ($recordingConfig['download'] ?? []);
+        if (!empty($downloadConfig['url'])) {
+            $token = $this->encodeDownloadToken([
+                'remote_path' => ltrim($recording, '/'),
+            ]);
+
+            $result['available'] = true;
+            $result['download_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName]);
+            $result['stream_url'] = route('ami.calls.recordings.download', ['token' => $token, 'name' => $fileName, 'inline' => 1]);
+            $result['token'] = $token;
+        }
+
         if (!$result['available']) {
             $baseUrl = $recordingConfig['base_url'] ?? null;
             if ($baseUrl) {

--- a/packages/behin-ami/src/config/behin-ami.php
+++ b/packages/behin-ami/src/config/behin-ami.php
@@ -18,6 +18,13 @@ return [
         'prefix' => env('AMI_RECORDINGS_PREFIX', ''),
         'base_path' => env('AMI_RECORDINGS_BASE_PATH'),
         'base_url' => env('AMI_RECORDINGS_BASE_URL'),
+        'download' => [
+            'url' => env('AMI_RECORDINGS_DOWNLOAD_URL'),
+            'username' => env('AMI_RECORDINGS_DOWNLOAD_USERNAME'),
+            'password' => env('AMI_RECORDINGS_DOWNLOAD_PASSWORD'),
+            'verify_ssl' => env('AMI_RECORDINGS_DOWNLOAD_VERIFY_SSL', false),
+            'timeout' => env('AMI_RECORDINGS_DOWNLOAD_TIMEOUT'),
+        ],
         'issabel' => [
             'base_url' => env('AMI_ISSABEL_BASE_URL'),
             'username' => env('AMI_ISSABEL_USERNAME'),

--- a/packages/behin-simple-workflow-report/src/Controllers/Core/RecordingController.php
+++ b/packages/behin-simple-workflow-report/src/Controllers/Core/RecordingController.php
@@ -23,16 +23,42 @@ class RecordingController extends Controller
         $recordingFile = $record->recordingfile;
         $fileName = basename($recordingFile);
 
-        // 2️⃣ ساخت URL کامل فایل (فرض بر اینه recordings از طریق وب سرو میشن)
-        $baseUrl = config('behin-ami.recordings.base_url'); // مثلاً https://91.247.171.3/recordings/
-        $url = rtrim($baseUrl, '/') . '/' . ltrim($recordingFile, '/');
+        $recordingsConfig = config('behin-ami.recordings', []);
+        $downloadConfig = $recordingsConfig['download'] ?? [];
+
+        // 2️⃣ ساخت URL کامل فایل با استفاده از اسکریپت دانلود جدید یا مسیر قبلی
+        if (!empty($downloadConfig['url'])) {
+            $downloadUrl = rtrim($downloadConfig['url'], '/');
+            $separator = str_contains($downloadUrl, '?') ? '&' : '?';
+            $url = $downloadUrl . $separator . 'file=' . urlencode($fileName);
+        } else {
+            $baseUrl = $recordingsConfig['base_url'] ?? null; // مثلاً https://91.247.171.3/recordings/
+            if (!$baseUrl) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'آدرس دانلود فایل در تنظیمات تعریف نشده است.'
+                ], 500);
+            }
+            $url = rtrim($baseUrl, '/') . '/' . ltrim($recordingFile, '/');
+        }
 
         // 3️⃣ اگر ایزابل نیاز به Basic Auth دارد
-        $username = env('AMI_WEB_USER', null);
-        $password = env('AMI_WEB_PASSWORD', null);
+        $username = $downloadConfig['username'] ?? env('AMI_WEB_USER', null);
+        $password = $downloadConfig['password'] ?? env('AMI_WEB_PASSWORD', null);
+
+        $verifySsl = $downloadConfig['verify_ssl'] ?? false;
+        if (!is_bool($verifySsl)) {
+            $filteredVerify = filter_var($verifySsl, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            $verifySsl = $filteredVerify ?? false;
+        }
+
+        $httpOptions = ['verify' => $verifySsl];
+        if (!empty($downloadConfig['timeout'])) {
+            $httpOptions['timeout'] = (int) $downloadConfig['timeout'];
+        }
 
         try {
-            $http = Http::withOptions(['verify' => false]);
+            $http = Http::withOptions($httpOptions);
             if ($username && $password) {
                 $http = $http->withBasicAuth($username, $password);
             }


### PR DESCRIPTION
## Summary
- stream remote recordings through the Issabel download script when configured
- generate download tokens when only the Issabel download script is available for a recording

## Testing
- php artisan test *(fails: vendor dependency CarbonPeriod constant mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68e63373582c8332bc9ace8fe5424854