### PR TITLE
Add panel creation route and view

### DIFF
--- a/packages/solar-plant-requests/resources/views/panels/create.blade.php
+++ b/packages/solar-plant-requests/resources/views/panels/create.blade.php
@@ -1,0 +1,19 @@
+@extends('behin-layouts.app')
+
+@section('content')
+    <div class="container">
+        @if (session()->has('success'))
+            <div class="alert alert-success">
+                {{ session('success') }}
+            </div>
+        @endif
+
+        @if (session()->has('error'))
+            <div class="alert alert-danger">
+                {{ session('error') }}
+            </div>
+        @endif
+
+        @include('solar-plant-requests::panels.add-panel-to-request')
+    </div>
+@endsection

--- a/packages/solar-plant-requests/routes/web.php
+++ b/packages/solar-plant-requests/routes/web.php
@@ -26,6 +26,7 @@ Route::middleware(['web', 'auth'])->prefix('solar-plant-requests')->name('solar-
     });
 
     Route::prefix('panel')->name('panel.')->group(function () {
+        Route::get('{solarPlantRequest}/create', [CreateController::class, 'create'])->name('create');
         Route::post('{solarPlantRequest}/store', [CreateController::class, 'addPanelToRequest'])->name('store');
     });
 

--- a/packages/solar-plant-requests/src/Http/Controllers/Panel/CreateController.php
+++ b/packages/solar-plant-requests/src/Http/Controllers/Panel/CreateController.php
@@ -2,14 +2,24 @@
 
 namespace SolarPlantRequests\Http\Controllers\Panel;
 
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use SolarPlantRequests\Enums\PanelStatus;
+use SolarPlantRequests\Http\Controllers\PanelManufacturer\GetController as PanelManufacturerGetController;
 use SolarPlantRequests\Models\Panel;
 use SolarPlantRequests\Models\SolarPlantRequest;
 
 class CreateController
 {
+    public function create(SolarPlantRequest $solarPlantRequest): View
+    {
+        return view('solar-plant-requests::panels.create', [
+            'solarPlantRequest' => $solarPlantRequest,
+            'manufacturers' => PanelManufacturerGetController::getAll(),
+        ]);
+    }
+
     public function addPanelToRequest(Request $request, SolarPlantRequest $solarPlantRequest)
     {
         $validated = $request->validate([


### PR DESCRIPTION
## Summary
- add a GET route for opening the panel creation form within solar plant requests
- add controller handler to provide panel creation view with manufacturer options
- add blade template that renders the panel creation form

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926c29f78848332816bb22ee781cb5d)